### PR TITLE
Update io_bazel dependency, jars, and tests

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 # Needed for generating the Stardoc release binary.
 git_repository(
     name = "io_bazel",
-    commit = "0bb860d20d171b30e31aa898f6403d082cb5aa1b",  # Sep 9, 2019
+    commit = "5eeccd8a647df10d154d3b86e9732e7f263c96db",  # Oct 7, 2019
     remote = "https://github.com/bazelbuild/bazel.git",
 )
 

--- a/docs/stardoc_rule.md
+++ b/docs/stardoc_rule.md
@@ -5,7 +5,8 @@
 ## stardoc
 
 <pre>
-stardoc(<a href="#stardoc-name">name</a>, <a href="#stardoc-aspect_template">aspect_template</a>, <a href="#stardoc-deps">deps</a>, <a href="#stardoc-format">format</a>, <a href="#stardoc-func_template">func_template</a>, <a href="#stardoc-header_template">header_template</a>, <a href="#stardoc-input">input</a>, <a href="#stardoc-out">out</a>, <a href="#stardoc-provider_template">provider_template</a>, <a href="#stardoc-renderer">renderer</a>, <a href="#stardoc-rule_template">rule_template</a>, <a href="#stardoc-semantic_flags">semantic_flags</a>, <a href="#stardoc-stardoc">stardoc</a>, <a href="#stardoc-symbol_names">symbol_names</a>)
+stardoc(<a href="#stardoc-name">name</a>, <a href="#stardoc-aspect_template">aspect_template</a>, <a href="#stardoc-deps">deps</a>, <a href="#stardoc-format">format</a>, <a href="#stardoc-func_template">func_template</a>, <a href="#stardoc-header_template">header_template</a>, <a href="#stardoc-input">input</a>, <a href="#stardoc-out">out</a>,
+        <a href="#stardoc-provider_template">provider_template</a>, <a href="#stardoc-renderer">renderer</a>, <a href="#stardoc-rule_template">rule_template</a>, <a href="#stardoc-semantic_flags">semantic_flags</a>, <a href="#stardoc-stardoc">stardoc</a>, <a href="#stardoc-symbol_names">symbol_names</a>)
 </pre>
 
 
@@ -17,21 +18,21 @@ This rule is an experimental replacement for the existing skylark_doc rule.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| aspect_template |  The input file template for generating documentation of aspects.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
-| deps |  A list of skylark_library dependencies which the input depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional |
-| format |  The format of the output file.   | String | optional |
-| func_template |  The input file template for generating documentation of functions.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
-| header_template |  The input file template for the header of the output documentation.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
-| input |  The starlark file to generate documentation for.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
-| out |  The (markdown) file to which documentation will be output.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| provider_template |  The input file template for generating documentation of providers.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
-| renderer |  The location of the renderer tool.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
-| rule_template |  The input file template for generating documentation of rules.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
-| semantic_flags |  A list of canonical flags to affect Starlark semantics for the Starlark interpretter<br>during documentation generation. This should only be used to maintain compatibility with<br>non-default semantic flags required to use the given Starlark symbols.<br><br>For example, if <code>//foo:bar.bzl</code> does not build except when a user would specify<br><code>--incompatible_foo_semantic=false</code>, then this attribute should contain<br>"--incompatible_foo_semantic=false".   | List of strings | optional |
-| stardoc |  The location of the stardoc tool.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
-| symbol_names |  A list of symbol names to generate documentation for. These should correspond to<br>the names of rule definitions in the input file. If this list is empty, then<br>documentation for all exported rule definitions will be generated.   | List of strings | optional |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| aspect_template |  The input file template for generating documentation of aspects.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //stardoc:templates/markdown_tables/aspect.vm |
+| deps |  A list of skylark_library dependencies which the input depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| format |  The format of the output file.   | String | optional | "markdown" |
+| func_template |  The input file template for generating documentation of functions.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //stardoc:templates/markdown_tables/func.vm |
+| header_template |  The input file template for the header of the output documentation.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //stardoc:templates/markdown_tables/header.vm |
+| input |  The starlark file to generate documentation for.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| out |  The (markdown) file to which documentation will be output.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| provider_template |  The input file template for generating documentation of providers.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //stardoc:templates/markdown_tables/provider.vm |
+| renderer |  The location of the renderer tool.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //stardoc:renderer |
+| rule_template |  The input file template for generating documentation of rules.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //stardoc:templates/markdown_tables/rule.vm |
+| semantic_flags |  A list of canonical flags to affect Starlark semantics for the Starlark interpretter during documentation generation. This should only be used to maintain compatibility with non-default semantic flags required to use the given Starlark symbols.<br><br>For example, if <code>//foo:bar.bzl</code> does not build except when a user would specify <code>--incompatible_foo_semantic=false</code>, then this attribute should contain "--incompatible_foo_semantic=false".   | List of strings | optional | [] |
+| stardoc |  The location of the stardoc tool.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //stardoc:stardoc |
+| symbol_names |  A list of symbol names to generate documentation for. These should correspond to the names of rule definitions in the input file. If this list is empty, then documentation for all exported rule definitions will be generated.   | List of strings | optional | [] |
 
 

--- a/stardoc/templates/markdown_tables/aspect.vm
+++ b/stardoc/templates/markdown_tables/aspect.vm
@@ -24,9 +24,9 @@ $aspectInfo.getDocString()
 
 #if (!$aspectInfo.getAttributeList().isEmpty())
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
 #foreach ($attribute in $aspectInfo.getAttributeList())
-| $attribute.name | #if(!$attribute.docString.isEmpty()) ${util.markdownCellFormat($attribute.docString)} #else - #end  | ${util.attributeTypeString($attribute)} | ${util.mandatoryString($attribute)} |
+| $attribute.name | #if(!$attribute.docString.isEmpty()) ${util.markdownCellFormat($attribute.docString)} #else - #end  | ${util.attributeTypeString($attribute)} | ${util.mandatoryString($attribute)} |  $attribute.defaultValue |
 #end
 #end

--- a/stardoc/templates/markdown_tables/rule.vm
+++ b/stardoc/templates/markdown_tables/rule.vm
@@ -12,9 +12,9 @@ ${ruleInfo.docString}
 
 #if (!$ruleInfo.getAttributeList().isEmpty())
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
 #foreach ($attribute in $ruleInfo.getAttributeList())
-| $attribute.name | #if(!$attribute.docString.isEmpty()) ${util.markdownCellFormat($attribute.docString)} #else - #end  | ${util.attributeTypeString($attribute)} | ${util.mandatoryString($attribute)} |
+| $attribute.name | #if(!$attribute.docString.isEmpty()) ${util.markdownCellFormat($attribute.docString)} #else - #end  | ${util.attributeTypeString($attribute)} | ${util.mandatoryString($attribute)} | $attribute.defaultValue |
 #end
 #end

--- a/test/BUILD
+++ b/test/BUILD
@@ -231,6 +231,12 @@ stardoc_test(
     test = "html_tables",
 )
 
+stardoc_test(
+    name = "attribute_defaults_test",
+    golden_file = "testdata/attribute_defaults_test/golden.txt",
+    input_file = "testdata/attribute_defaults_test/input.bzl",
+)
+
 genrule(
     name = "generate_bzl_test_dep",
     srcs = ["testdata/generated_bzl_test/dep.bzl.tpl"],

--- a/test/testdata/android_basic_test/golden.txt
+++ b/test/testdata/android_basic_test/golden.txt
@@ -13,12 +13,12 @@ This rule does android-related things.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| fourth |  -   | Boolean | optional |
-| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
-| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| fourth |  -   | Boolean | optional | False |
+| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 

--- a/test/testdata/angle_bracket_test/golden.txt
+++ b/test/testdata/angle_bracket_test/golden.txt
@@ -13,10 +13,10 @@ Rule with <brackets>
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| useless |  Args with some tags: &lt;tag1&gt;, &lt;tag2&gt;   | String | optional |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| useless |  Args with some tags: &lt;tag1&gt;, &lt;tag2&gt;   | String | optional | "Find <brackets>" |
 
 
 <a name="#bracketuse"></a>

--- a/test/testdata/apple_basic_test/golden.txt
+++ b/test/testdata/apple_basic_test/golden.txt
@@ -13,12 +13,12 @@ This rule does apple-related things.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| fourth |  -   | Boolean | optional |
-| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
-| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| fourth |  -   | Boolean | optional | False |
+| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 

--- a/test/testdata/aspect_test/golden.txt
+++ b/test/testdata/aspect_test/golden.txt
@@ -40,11 +40,11 @@ This is my aspect. It does stuff.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |   |
+| first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |   |
+| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |   |
 
 
 <a name="#other_aspect"></a>
@@ -68,9 +68,9 @@ This is another aspect.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| third |  -   | Integer | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |   |
+| third |  -   | Integer | required |   |
 
 

--- a/test/testdata/attribute_defaults_test/golden.txt
+++ b/test/testdata/attribute_defaults_test/golden.txt
@@ -1,0 +1,72 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+<a name="#my_rule"></a>
+
+## my_rule
+
+<pre>
+my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-a">a</a>, <a href="#my_rule-b">b</a>, <a href="#my_rule-c">c</a>, <a href="#my_rule-d">d</a>, <a href="#my_rule-e">e</a>, <a href="#my_rule-f">f</a>, <a href="#my_rule-g">g</a>, <a href="#my_rule-h">h</a>, <a href="#my_rule-i">i</a>, <a href="#my_rule-j">j</a>, <a href="#my_rule-k">k</a>, <a href="#my_rule-l">l</a>, <a href="#my_rule-m">m</a>, <a href="#my_rule-n">n</a>, <a href="#my_rule-o">o</a>, <a href="#my_rule-p">p</a>, <a href="#my_rule-q">q</a>, <a href="#my_rule-r">r</a>, <a href="#my_rule-s">s</a>, <a href="#my_rule-t">t</a>, <a href="#my_rule-u">u</a>, <a href="#my_rule-v">v</a>, <a href="#my_rule-w">w</a>)
+</pre>
+
+This is my rule. It does stuff.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| a |  Some bool   | Boolean | optional | False |
+| b |  Some int   | Integer | optional | 2 |
+| c |  Some int_list   | List of integers | optional | [0, 1] |
+| d |  Some label   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //foo:bar |
+| e |  Some label_keyed_string_dict   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | optional | {"//foo:bar": "hello", "//bar:baz": "goodbye"} |
+| f |  Some label_list   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | ["//foo:bar", "//bar:baz"] |
+| g |  Some string   | String | optional | "" |
+| h |  Some string_dict   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {"animal": "bunny", "color": "orange"} |
+| i |  Some string_list   | List of strings | optional | ["cat", "dog"] |
+| j |  Some string_list_dict   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> List of strings</a> | optional | {"animal": ["cat", "bunny"], "color": ["blue", "orange"]} |
+| k |  Some bool   | Boolean | required |  |
+| l |  Some int   | Integer | required |  |
+| m |  Some int_list   | List of integers | required |  |
+| n |  Some label   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| o |  Some label_keyed_string_dict   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | required |  |
+| p |  Some label_list   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+| q |  Some string   | String | required |  |
+| r |  Some string_dict   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| s |  Some string_list   | List of strings | required |  |
+| t |  Some string_list_dict   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> List of strings</a> | required |  |
+| u |  -   | String | optional | "" |
+| v |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| w |  -   | Integer | optional | 0 |
+
+
+<a name="#my_aspect"></a>
+
+## my_aspect
+
+<pre>
+my_aspect(<a href="#my_aspect-name">name</a>, <a href="#my_aspect-y">y</a>, <a href="#my_aspect-z">z</a>)
+</pre>
+
+This is my aspect. It does stuff.
+
+**ASPECT ATTRIBUTES**
+
+
+| Name | Type |
+| :-------------: | :-------------: |
+| deps| String |
+| attr_aspect| String |
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |   |
+| y |  some string   | String | optional |  "why" |
+| z |  -   | String | required |   |
+
+

--- a/test/testdata/attribute_defaults_test/input.bzl
+++ b/test/testdata/attribute_defaults_test/input.bzl
@@ -1,0 +1,57 @@
+"""A golden test to verify attribute default values."""
+
+def _my_rule_impl(ctx):
+    return []
+
+def _my_aspect_impl(target, ctx):
+    return []
+
+my_aspect = aspect(
+    implementation = _my_aspect_impl,
+    doc = "This is my aspect. It does stuff.",
+    attr_aspects = ["deps", "attr_aspect"],
+    attrs = {
+        "_x": attr.label(mandatory = True),
+        "y": attr.string(default = "why", doc = "some string"),
+        "z": attr.string(mandatory = True),
+    },
+)
+
+my_rule = rule(
+    implementation = _my_rule_impl,
+    doc = "This is my rule. It does stuff.",
+    attrs = {
+        "a": attr.bool(default = False, doc = "Some bool"),
+        "b": attr.int(default = 2, doc = "Some int"),
+        "c": attr.int_list(default = [0, 1], doc = "Some int_list"),
+        "d": attr.label(default = "//foo:bar", doc = "Some label"),
+        "e": attr.label_keyed_string_dict(
+            default = {"//foo:bar": "hello", "//bar:baz": "goodbye"},
+            doc = "Some label_keyed_string_dict",
+        ),
+        "f": attr.label_list(default = ["//foo:bar", "//bar:baz"], doc = "Some label_list"),
+        "g": attr.string(default = "", doc = "Some string"),
+        "h": attr.string_dict(
+            default = {"animal": "bunny", "color": "orange"},
+            doc = "Some string_dict",
+        ),
+        "i": attr.string_list(default = ["cat", "dog"], doc = "Some string_list"),
+        "j": attr.string_list_dict(
+            default = {"animal": ["cat", "bunny"], "color": ["blue", "orange"]},
+            doc = "Some string_list_dict",
+        ),
+        "k": attr.bool(mandatory = True, doc = "Some bool"),
+        "l": attr.int(mandatory = True, doc = "Some int"),
+        "m": attr.int_list(mandatory = True, doc = "Some int_list"),
+        "n": attr.label(mandatory = True, doc = "Some label"),
+        "o": attr.label_keyed_string_dict(mandatory = True, doc = "Some label_keyed_string_dict"),
+        "p": attr.label_list(mandatory = True, doc = "Some label_list"),
+        "q": attr.string(mandatory = True, doc = "Some string"),
+        "r": attr.string_dict(mandatory = True, doc = "Some string_dict"),
+        "s": attr.string_list(mandatory = True, doc = "Some string_list"),
+        "t": attr.string_list_dict(mandatory = True, doc = "Some string_list_dict"),
+        "u": attr.string(),
+        "v": attr.label(),
+        "w": attr.int()
+    },
+)

--- a/test/testdata/attribute_types_test/golden.txt
+++ b/test/testdata/attribute_types_test/golden.txt
@@ -13,20 +13,20 @@ This is my rule. It does stuff.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| a |  Some bool   | Boolean | required |
-| b |  Some int   | Integer | required |
-| c |  Some int_list   | List of integers | required |
-| d |  Some label   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| e |  Some label_keyed_string_dict   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | required |
-| f |  Some label_list   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |
-| g |  Some output   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
-| h |  Some output_list   | List of labels | optional |
-| i |  Some string   | String | required |
-| j |  Some string_dict   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
-| k |  Some string_list   | List of strings | required |
-| l |  Some string_list_dict   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> List of strings</a> | optional |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| a |  Some bool   | Boolean | required |  |
+| b |  Some int   | Integer | required |  |
+| c |  Some int_list   | List of integers | required |  |
+| d |  Some label   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| e |  Some label_keyed_string_dict   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | required |  |
+| f |  Some label_list   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+| g |  Some output   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| h |  Some output_list   | List of labels | optional | None |
+| i |  Some string   | String | required |  |
+| j |  Some string_dict   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| k |  Some string_list   | List of strings | required |  |
+| l |  Some string_list_dict   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> List of strings</a> | optional | {} |
 
 

--- a/test/testdata/cc_api_test/golden.txt
+++ b/test/testdata/cc_api_test/golden.txt
@@ -13,13 +13,13 @@ This rule does C++-related things.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| fourth |  -   | Boolean | optional |
-| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
-| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| fourth |  -   | Boolean | optional | False |
+| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
 <a name="#exercise_the_api"></a>

--- a/test/testdata/cpp_basic_test/golden.txt
+++ b/test/testdata/cpp_basic_test/golden.txt
@@ -13,12 +13,12 @@ This rule does cpp-related things.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| fourth |  -   | Boolean | optional |
-| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
-| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| fourth |  -   | Boolean | optional | False |
+| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 

--- a/test/testdata/filter_rules_test/golden.txt
+++ b/test/testdata/filter_rules_test/golden.txt
@@ -13,11 +13,11 @@ This is my rule. It does stuff.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| first |  first my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| first |  first my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 
 
 <a name="#whitelisted_dep_rule"></a>
@@ -33,10 +33,10 @@ This is the dep rule. It does stuff.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| first |  dep's my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| first |  dep's my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 
 

--- a/test/testdata/function_basic_test/golden.txt
+++ b/test/testdata/function_basic_test/golden.txt
@@ -5,7 +5,8 @@
 ## check_sources
 
 <pre>
-check_sources(<a href="#check_sources-name">name</a>, <a href="#check_sources-required_param">required_param</a>, <a href="#check_sources-bool_param">bool_param</a>, <a href="#check_sources-srcs">srcs</a>, <a href="#check_sources-string_param">string_param</a>, <a href="#check_sources-int_param">int_param</a>, <a href="#check_sources-dict_param">dict_param</a>, <a href="#check_sources-struct_param">struct_param</a>)
+check_sources(<a href="#check_sources-name">name</a>, <a href="#check_sources-required_param">required_param</a>, <a href="#check_sources-bool_param">bool_param</a>, <a href="#check_sources-srcs">srcs</a>, <a href="#check_sources-string_param">string_param</a>, <a href="#check_sources-int_param">int_param</a>, <a href="#check_sources-dict_param">dict_param</a>,
+              <a href="#check_sources-struct_param">struct_param</a>)
 </pre>
 
 Runs some checks on the given source files.

--- a/test/testdata/generated_bzl_test/golden.txt
+++ b/test/testdata/generated_bzl_test/golden.txt
@@ -13,10 +13,10 @@ This is my rule. It does stuff.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| first |  first my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| first |  first my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 
 

--- a/test/testdata/java_basic_test/golden.txt
+++ b/test/testdata/java_basic_test/golden.txt
@@ -13,12 +13,12 @@ This rule does java-related things.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| fourth |  -   | Boolean | optional |
-| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
-| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| fourth |  -   | Boolean | optional | False |
+| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 

--- a/test/testdata/misc_apis_test/golden.txt
+++ b/test/testdata/misc_apis_test/golden.txt
@@ -13,14 +13,14 @@ This rule exercises some of the build API.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| deps |  A list of dependencies.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional |
-| extra_arguments |  -   | List of strings | optional |
-| out |  The output file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| src |  The source file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
-| tool |  The location of the tool to use.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| deps |  A list of dependencies.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| extra_arguments |  -   | List of strings | optional | [] |
+| out |  The output file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| src |  The source file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| tool |  The location of the tool to use.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //foo/bar/baz:target |
 
 
 <a name="#MyInfo"></a>

--- a/test/testdata/multiple_files_test/golden.txt
+++ b/test/testdata/multiple_files_test/golden.txt
@@ -13,11 +13,11 @@ This is my rule. It does stuff.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| first |  first my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| first |  first my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 
 
 <a name="#other_rule"></a>
@@ -33,11 +33,11 @@ This is another rule.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| fourth |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
-| third |  third other_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| fourth |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| third |  third other_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
 <a name="#yet_another_rule"></a>
@@ -53,10 +53,10 @@ This is yet another rule
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| fifth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| fifth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
 <a name="#top_fun"></a>

--- a/test/testdata/multiple_rules_test/golden.txt
+++ b/test/testdata/multiple_rules_test/golden.txt
@@ -13,11 +13,11 @@ This is my rule. It does stuff.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 
 
 <a name="#other_rule"></a>
@@ -33,11 +33,11 @@ This is another rule.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| fourth |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
-| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| fourth |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
 <a name="#yet_another_rule"></a>
@@ -53,10 +53,10 @@ This is yet another rule
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| fifth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| fifth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
 <a name="#my_rule_impl"></a>

--- a/test/testdata/proto_format_test/golden.raw
+++ b/test/testdata/proto_format_test/golden.raw
@@ -1,9 +1,10 @@
 
-}
+‰
 
 my_exampleSmall example of rule.*
-nameA unique name for this target. +
-uselessThis argument will be ignored.•
+nameA unique name for this target. 7
+uselessThis argument will be ignored.2
+"ignoreme"•
 example$Stores information about an example. 
 fooA string representing foo 
 barA string representing bar 

--- a/test/testdata/proto_format_test/golden.txt
+++ b/test/testdata/proto_format_test/golden.txt
@@ -1,16 +1,0 @@
-
-}
-
-my_exampleSmall example of rule.*
-nameA unique name for this target. +
-uselessThis argument will be ignored.•
-example$Stores information about an example. 
-fooA string representing foo 
-barA string representing bar 
-bazA string representing bazÆ
-check_function%
-fooA unique name for this rule. ŒRuns some checks on the given function parameter.
-
-This rule runs checks on a given function parameter.
-Use `bazel build` to run the check.
-* Input file for proto format test

--- a/test/testdata/providers_for_attributes_test/golden.txt
+++ b/test/testdata/providers_for_attributes_test/golden.txt
@@ -13,15 +13,15 @@ This rule does things.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| fifth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
-| first |  this is the first attribute.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | optional |
-| fourth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
-| second |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional |
-| sixth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
-| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| fifth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| first |  this is the first attribute.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | optional | {} |
+| fourth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| second |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| sixth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
 <a name="#MyProviderInfo"></a>

--- a/test/testdata/py_rule_test/golden.txt
+++ b/test/testdata/py_rule_test/golden.txt
@@ -13,14 +13,14 @@ This rule does python-related things.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| fifth |  Hey look, its the fifth thing!   | Boolean | optional |
-| first |  this is the first doc string!   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| fourth |  the fourth doc string.   | Boolean | optional |
-| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
-| sixth |  it's the sixth thing.   | List of integers | optional |
-| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| fifth |  Hey look, its the fifth thing!   | Boolean | optional | True |
+| first |  this is the first doc string!   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| fourth |  the fourth doc string.   | Boolean | optional | False |
+| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| sixth |  it's the sixth thing.   | List of integers | optional | range(0, 10) |
+| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 

--- a/test/testdata/repo_rules_test/golden.txt
+++ b/test/testdata/repo_rules_test/golden.txt
@@ -13,9 +13,9 @@ Minimal example of a repository rule.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this repository.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| useless |  This argument will be ingored. You don't have to specify it, but you may.   | String | optional |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this repository.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| useless |  This argument will be ingored. You don't have to specify it, but you may.   | String | optional | "ignoreme" |
 
 

--- a/test/testdata/same_level_file_test/golden.txt
+++ b/test/testdata/same_level_file_test/golden.txt
@@ -13,10 +13,10 @@ This is my rule. It does stuff.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| first |  first my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| first |  first my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 
 

--- a/test/testdata/simple_test/golden.txt
+++ b/test/testdata/simple_test/golden.txt
@@ -13,12 +13,12 @@ This is my rule. It does stuff.
 **ATTRIBUTES**
 
 
-| Name  | Description | Type | Mandatory |
-| :-------------: | :-------------: | :-------------: | :-------------: |
-| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |
-| first |  first doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
-| fourth |  fourth doc string   | Boolean | optional |
-| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |
-| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |
+| Name  | Description | Type | Mandatory | Default |
+| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| first |  first doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| fourth |  fourth doc string   | Boolean | optional | False |
+| second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 

--- a/test/testdata/struct_default_value_test/golden.txt
+++ b/test/testdata/struct_default_value_test/golden.txt
@@ -5,7 +5,8 @@
 ## check_struct_default_values
 
 <pre>
-check_struct_default_values(<a href="#check_struct_default_values-struct_no_args">struct_no_args</a>, <a href="#check_struct_default_values-struct_arg">struct_arg</a>, <a href="#check_struct_default_values-struct_args">struct_args</a>, <a href="#check_struct_default_values-struct_int_args">struct_int_args</a>, <a href="#check_struct_default_values-struct_struct_args">struct_struct_args</a>)
+check_struct_default_values(<a href="#check_struct_default_values-struct_no_args">struct_no_args</a>, <a href="#check_struct_default_values-struct_arg">struct_arg</a>, <a href="#check_struct_default_values-struct_args">struct_args</a>, <a href="#check_struct_default_values-struct_int_args">struct_int_args</a>,
+                            <a href="#check_struct_default_values-struct_struct_args">struct_struct_args</a>)
 </pre>
 
 Checks the default values of structs.


### PR DESCRIPTION
This new cut includes:

Render defaults for non-mandatory rule and aspect attributes. (https://github.com/bazelbuild/bazel/commit/5eeccd8a647df10d154d3b86e9732e7f263c96db)