### PR TITLE
Left-align markdown attribute tables.

### DIFF
--- a/docs/stardoc_rule.md
+++ b/docs/stardoc_rule.md
@@ -19,7 +19,7 @@ This rule is an experimental replacement for the existing skylark_doc rule.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="stardoc-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="stardoc-aspect_template"></a>aspect_template |  The input file template for generating documentation of aspects.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //stardoc:templates/markdown_tables/aspect.vm |
 | <a name="stardoc-deps"></a>deps |  A list of skylark_library dependencies which the input depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |

--- a/stardoc/templates/markdown_tables/aspect.vm
+++ b/stardoc/templates/markdown_tables/aspect.vm
@@ -13,7 +13,7 @@ $aspectInfo.getDocString()
 #if (!$aspectInfo.getAspectAttributeList().isEmpty())
 
 | Name | Type |
-| :-------------: | :-------------: |
+| :------------- | :------------- |
 #foreach ($aspectAttribute in $aspectInfo.getAspectAttributeList())
 | $aspectAttribute| String |
 #end
@@ -25,7 +25,7 @@ $aspectInfo.getDocString()
 #if (!$aspectInfo.getAttributeList().isEmpty())
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 #foreach ($attribute in $aspectInfo.getAttributeList())
 | <a name="${aspectName}-${attribute.name}"></a>$attribute.name | #if(!$attribute.docString.isEmpty()) ${util.markdownCellFormat($attribute.docString)} #else - #end  | ${util.attributeTypeString($attribute)} | ${util.mandatoryString($attribute)} |  $attribute.defaultValue |
 #end

--- a/stardoc/templates/markdown_tables/func.vm
+++ b/stardoc/templates/markdown_tables/func.vm
@@ -13,7 +13,7 @@ ${funcInfo.docString}
 #if (!$funcInfo.getParameterList().isEmpty())
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 #foreach ($param in $funcInfo.getParameterList())
 | <a name="${funcInfo.functionName}-${param.name}"></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end  | #if(!$param.getDefaultValue().isEmpty()) <code>$param.getDefaultValue()</code> #else none #end|
 #end

--- a/stardoc/templates/markdown_tables/provider.vm
+++ b/stardoc/templates/markdown_tables/provider.vm
@@ -13,7 +13,7 @@ ${providerInfo.docString}
 #if (!$providerInfo.fieldInfoList.isEmpty())
 
 | Name  | Description |
-| :-------------: | :-------------: |
+| :------------- | :------------- |
 #foreach ($field in $providerInfo.fieldInfoList)
 | <a name="${providerName}-${field.name}"></a>$field.name | #if(!$field.docString.isEmpty()) ${util.markdownCellFormat($field.docString)} #else - #end   |
 #end

--- a/stardoc/templates/markdown_tables/rule.vm
+++ b/stardoc/templates/markdown_tables/rule.vm
@@ -13,7 +13,7 @@ ${ruleInfo.docString}
 #if (!$ruleInfo.getAttributeList().isEmpty())
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 #foreach ($attribute in $ruleInfo.getAttributeList())
 | <a name="${ruleName}-${attribute.name}"></a>$attribute.name | #if(!$attribute.docString.isEmpty()) ${util.markdownCellFormat($attribute.docString)} #else - #end  | ${util.attributeTypeString($attribute)} | ${util.mandatoryString($attribute)} | $attribute.defaultValue |
 #end

--- a/test/testdata/android_basic_test/golden.md
+++ b/test/testdata/android_basic_test/golden.md
@@ -14,7 +14,7 @@ This rule does android-related things.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="android_related_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="android_related_rule-first"></a>first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a name="android_related_rule-fourth"></a>fourth |  -   | Boolean | optional | False |

--- a/test/testdata/angle_bracket_test/golden.md
+++ b/test/testdata/angle_bracket_test/golden.md
@@ -14,7 +14,7 @@ Rule with <brackets>
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="my_anglebrac-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="my_anglebrac-useless"></a>useless |  Args with some tags: &lt;tag1&gt;, &lt;tag2&gt;   | String | optional | "Find <brackets>" |
 
@@ -33,7 +33,7 @@ Information with <brackets>
 
 
 | Name  | Description |
-| :-------------: | :-------------: |
+| :------------- | :------------- |
 | <a name="bracketuse-foo"></a>foo |  A string representing &lt;foo&gt;    |
 | <a name="bracketuse-bar"></a>bar |  A string representing bar    |
 | <a name="bracketuse-baz"></a>baz |  A string representing baz    |
@@ -56,7 +56,7 @@ This rule runs checks on <angle brackets>.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="bracket_function-name"></a>name |  an arg with **formatted** docstring.   |  none |
 
 

--- a/test/testdata/apple_basic_test/golden.md
+++ b/test/testdata/apple_basic_test/golden.md
@@ -14,7 +14,7 @@ This rule does apple-related things.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="apple_related_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="apple_related_rule-first"></a>first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a name="apple_related_rule-fourth"></a>fourth |  -   | Boolean | optional | False |

--- a/test/testdata/aspect_test/golden.md
+++ b/test/testdata/aspect_test/golden.md
@@ -14,7 +14,7 @@ my_aspect_impl(<a href="#my_aspect_impl-ctx">ctx</a>)
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="my_aspect_impl-ctx"></a>ctx |  <p align="center"> - </p>   |  none |
 
 
@@ -32,7 +32,7 @@ This is my aspect. It does stuff.
 
 
 | Name | Type |
-| :-------------: | :-------------: |
+| :------------- | :------------- |
 | deps| String |
 | attr_aspect| String |
 
@@ -41,7 +41,7 @@ This is my aspect. It does stuff.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="my_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |   |
 | <a name="my_aspect-first"></a>first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |   |
 | <a name="my_aspect-second"></a>second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |   |
@@ -61,7 +61,7 @@ This is another aspect.
 
 
 | Name | Type |
-| :-------------: | :-------------: |
+| :------------- | :------------- |
 | *| String |
 
 
@@ -69,7 +69,7 @@ This is another aspect.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="other_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |   |
 | <a name="other_aspect-third"></a>third |  -   | Integer | required |   |
 

--- a/test/testdata/attribute_defaults_test/golden.md
+++ b/test/testdata/attribute_defaults_test/golden.md
@@ -14,7 +14,7 @@ This is my rule. It does stuff.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="my_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="my_rule-a"></a>a |  Some bool   | Boolean | optional | False |
 | <a name="my_rule-b"></a>b |  Some int   | Integer | optional | 2 |
@@ -55,7 +55,7 @@ This is my aspect. It does stuff.
 
 
 | Name | Type |
-| :-------------: | :-------------: |
+| :------------- | :------------- |
 | deps| String |
 | attr_aspect| String |
 
@@ -64,7 +64,7 @@ This is my aspect. It does stuff.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="my_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |   |
 | <a name="my_aspect-y"></a>y |  some string   | String | optional |  "why" |
 | <a name="my_aspect-z"></a>z |  -   | String | required |   |

--- a/test/testdata/attribute_types_test/golden.md
+++ b/test/testdata/attribute_types_test/golden.md
@@ -14,7 +14,7 @@ This is my rule. It does stuff.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="my_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="my_rule-a"></a>a |  Some bool   | Boolean | required |  |
 | <a name="my_rule-b"></a>b |  Some int   | Integer | required |  |

--- a/test/testdata/cc_api_test/golden.md
+++ b/test/testdata/cc_api_test/golden.md
@@ -14,7 +14,7 @@ This rule does C++-related things.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="cpp_related_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="cpp_related_rule-first"></a>first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a name="cpp_related_rule-fourth"></a>fourth |  -   | Boolean | optional | False |
@@ -50,7 +50,7 @@ my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="my_rule_impl-ctx"></a>ctx |  <p align="center"> - </p>   |  none |
 
 

--- a/test/testdata/config_apis_test/golden.md
+++ b/test/testdata/config_apis_test/golden.md
@@ -14,7 +14,7 @@ int_setting(<a href="#int_setting-name">name</a>)
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="int_setting-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
@@ -32,7 +32,7 @@ string_flag(<a href="#string_flag-name">name</a>)
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="string_flag-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
@@ -64,7 +64,7 @@ A no-op transition function.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="transition_func-settings"></a>settings |  <p align="center"> - </p>   |  none |
 
 

--- a/test/testdata/cpp_basic_test/golden.md
+++ b/test/testdata/cpp_basic_test/golden.md
@@ -14,7 +14,7 @@ This rule does cpp-related things.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="cpp_related_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="cpp_related_rule-first"></a>first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a name="cpp_related_rule-fourth"></a>fourth |  -   | Boolean | optional | False |

--- a/test/testdata/filter_rules_test/golden.md
+++ b/test/testdata/filter_rules_test/golden.md
@@ -14,7 +14,7 @@ This is my rule. It does stuff.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="my_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="my_rule-first"></a>first |  first my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a name="my_rule-second"></a>second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
@@ -34,7 +34,7 @@ This is the dep rule. It does stuff.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="whitelisted_dep_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="whitelisted_dep_rule-first"></a>first |  dep's my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a name="whitelisted_dep_rule-second"></a>second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |

--- a/test/testdata/function_basic_test/golden.md
+++ b/test/testdata/function_basic_test/golden.md
@@ -19,7 +19,7 @@ Use `bazel build` to run the check.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="check_sources-name"></a>name |  A unique name for this rule.   |  none |
 | <a name="check_sources-required_param"></a>required_param |  Use your imagination.   |  none |
 | <a name="check_sources-bool_param"></a>bool_param |  <p align="center"> - </p>   |  <code>True</code> |
@@ -44,7 +44,7 @@ undocumented_function(<a href="#undocumented_function-a">a</a>, <a href="#undocu
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="undocumented_function-a"></a>a |  <p align="center"> - </p>   |  none |
 | <a name="undocumented_function-b"></a>b |  <p align="center"> - </p>   |  none |
 | <a name="undocumented_function-c"></a>c |  <p align="center"> - </p>   |  none |

--- a/test/testdata/generated_bzl_test/golden.md
+++ b/test/testdata/generated_bzl_test/golden.md
@@ -14,7 +14,7 @@ This is my rule. It does stuff.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="my_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="my_rule-first"></a>first |  first my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a name="my_rule-second"></a>second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |

--- a/test/testdata/java_basic_test/golden.md
+++ b/test/testdata/java_basic_test/golden.md
@@ -14,7 +14,7 @@ This rule does java-related things.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="java_related_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="java_related_rule-first"></a>first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a name="java_related_rule-fourth"></a>fourth |  -   | Boolean | optional | False |

--- a/test/testdata/local_repository_test/golden.md
+++ b/test/testdata/local_repository_test/golden.md
@@ -14,7 +14,7 @@ Returns the minimum of given elements.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="min-integers"></a>integers |  A list of integers. Must not be empty.   |  none |
 
 

--- a/test/testdata/macro_kwargs_test/golden.md
+++ b/test/testdata/macro_kwargs_test/golden.md
@@ -14,7 +14,7 @@ My args macro is OK.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="macro_with_args-name"></a>name |  The name of the test rule.   |  none |
 | <a name="macro_with_args-args"></a>args |  Other arguments to include   |  none |
 
@@ -36,7 +36,7 @@ Not much else to say.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="macro_with_both-name"></a>name |  The name of the test rule.   |  none |
 | <a name="macro_with_both-number"></a>number |  Some number used for important things   |  <code>3</code> |
 | <a name="macro_with_both-args"></a>args |  Other arguments to include   |  none |
@@ -64,7 +64,7 @@ vel mollis eros pellentesque.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="macro_with_kwargs-name"></a>name |  The name of the test rule.   |  none |
 | <a name="macro_with_kwargs-config"></a>config |  Config to use for my macro   |  none |
 | <a name="macro_with_kwargs-deps"></a>deps |  List of my macro's dependencies   |  <code>[]</code> |

--- a/test/testdata/misc_apis_test/golden.md
+++ b/test/testdata/misc_apis_test/golden.md
@@ -14,7 +14,7 @@ This rule exercises some of the build API.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="my_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="my_rule-deps"></a>deps |  A list of dependencies.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a name="my_rule-extra_arguments"></a>extra_arguments |  -   | List of strings | optional | [] |
@@ -37,7 +37,7 @@ MyInfo(<a href="#MyInfo-foo">foo</a>, <a href="#MyInfo-bar">bar</a>)
 
 
 | Name  | Description |
-| :-------------: | :-------------: |
+| :------------- | :------------- |
 | <a name="MyInfo-foo"></a>foo |  Something foo-related.    |
 | <a name="MyInfo-bar"></a>bar |  Something bar-related.    |
 
@@ -70,7 +70,7 @@ my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="my_rule_impl-ctx"></a>ctx |  <p align="center"> - </p>   |  none |
 
 

--- a/test/testdata/multi_level_namespace_test/golden.md
+++ b/test/testdata/multi_level_namespace_test/golden.md
@@ -14,7 +14,7 @@ Returns the minimum of given elements.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="my_namespace.min-integers"></a>integers |  A list of integers. Must not be empty.   |  none |
 
 
@@ -32,7 +32,7 @@ Returns the minimum of given elements.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="my_namespace.math.min-integers"></a>integers |  A list of integers. Must not be empty.   |  none |
 
 
@@ -64,7 +64,7 @@ Returns the minimum of given elements.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="my_namespace.one.two.min-integers"></a>integers |  A list of integers. Must not be empty.   |  none |
 
 

--- a/test/testdata/multi_level_namespace_test_with_whitelist/golden.md
+++ b/test/testdata/multi_level_namespace_test_with_whitelist/golden.md
@@ -14,7 +14,7 @@ Returns the minimum of given elements.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="my_namespace.min-integers"></a>integers |  <p align="center"> - </p>   |  none |
 
 
@@ -32,7 +32,7 @@ Returns the minimum of given elements.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="my_namespace.math.min-integers"></a>integers |  <p align="center"> - </p>   |  none |
 
 

--- a/test/testdata/multiple_files_test/golden.md
+++ b/test/testdata/multiple_files_test/golden.md
@@ -14,7 +14,7 @@ This is my rule. It does stuff.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="my_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="my_rule-first"></a>first |  first my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a name="my_rule-second"></a>second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
@@ -34,7 +34,7 @@ This is another rule.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="other_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="other_rule-fourth"></a>fourth |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 | <a name="other_rule-third"></a>third |  third other_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
@@ -54,7 +54,7 @@ This is yet another rule
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="yet_another_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="yet_another_rule-fifth"></a>fifth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
@@ -73,7 +73,7 @@ top_fun(<a href="#top_fun-a">a</a>, <a href="#top_fun-b">b</a>, <a href="#top_fu
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="top_fun-a"></a>a |  <p align="center"> - </p>   |  none |
 | <a name="top_fun-b"></a>b |  <p align="center"> - </p>   |  none |
 | <a name="top_fun-c"></a>c |  <p align="center"> - </p>   |  none |

--- a/test/testdata/multiple_rules_test/golden.md
+++ b/test/testdata/multiple_rules_test/golden.md
@@ -14,7 +14,7 @@ This is my rule. It does stuff.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="my_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="my_rule-first"></a>first |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a name="my_rule-second"></a>second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
@@ -34,7 +34,7 @@ This is another rule.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="other_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="other_rule-fourth"></a>fourth |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 | <a name="other_rule-third"></a>third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
@@ -54,7 +54,7 @@ This is yet another rule
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="yet_another_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="yet_another_rule-fifth"></a>fifth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
@@ -73,7 +73,7 @@ my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="my_rule_impl-ctx"></a>ctx |  <p align="center"> - </p>   |  none |
 
 

--- a/test/testdata/namespace_test/golden.md
+++ b/test/testdata/namespace_test/golden.md
@@ -14,7 +14,7 @@ Asserts the two given lists are not empty.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="my_namespace.assert_non_empty-some_list"></a>some_list |  The first list   |  none |
 | <a name="my_namespace.assert_non_empty-other_list"></a>other_list |  The second list   |  none |
 
@@ -33,7 +33,7 @@ Returns the minimum of given elements.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="my_namespace.min-integers"></a>integers |  A list of integers. Must not be empty.   |  none |
 
 
@@ -51,7 +51,7 @@ Joins the given strings with a delimiter.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="my_namespace.join_strings-strings"></a>strings |  A list of strings to join.   |  none |
 | <a name="my_namespace.join_strings-delimiter"></a>delimiter |  The delimiter to use   |  <code>", "</code> |
 

--- a/test/testdata/provider_basic_test/golden.md
+++ b/test/testdata/provider_basic_test/golden.md
@@ -14,7 +14,7 @@ Stores information about a foo.
 
 
 | Name  | Description |
-| :-------------: | :-------------: |
+| :------------- | :------------- |
 | <a name="MyFooInfo-bar"></a>bar |  (Undocumented)    |
 | <a name="MyFooInfo-baz"></a>baz |  (Undocumented)    |
 
@@ -50,7 +50,7 @@ Look on my works, ye mighty, and despair!
 
 
 | Name  | Description |
-| :-------------: | :-------------: |
+| :------------- | :------------- |
 | <a name="MyVeryDocumentedInfo-favorite_food"></a>favorite_food |  A string representing my favorite food    |
 | <a name="MyVeryDocumentedInfo-favorite_color"></a>favorite_color |  A string representing my favorite color    |
 

--- a/test/testdata/providers_for_attributes_test/golden.md
+++ b/test/testdata/providers_for_attributes_test/golden.md
@@ -14,7 +14,7 @@ This rule does things.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="my_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="my_rule-fifth"></a>fifth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a name="my_rule-first"></a>first |  this is the first attribute.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | optional | {} |
@@ -38,7 +38,7 @@ MyProviderInfo(<a href="#MyProviderInfo-foo">foo</a>, <a href="#MyProviderInfo-b
 
 
 | Name  | Description |
-| :-------------: | :-------------: |
+| :------------- | :------------- |
 | <a name="MyProviderInfo-foo"></a>foo |  Something foo-related.    |
 | <a name="MyProviderInfo-bar"></a>bar |  Something bar-related.    |
 
@@ -71,7 +71,7 @@ my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="my_rule_impl-ctx"></a>ctx |  <p align="center"> - </p>   |  none |
 
 

--- a/test/testdata/py_rule_test/golden.md
+++ b/test/testdata/py_rule_test/golden.md
@@ -14,7 +14,7 @@ This rule does python-related things.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="py_related_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="py_related_rule-fifth"></a>fifth |  Hey look, its the fifth thing!   | Boolean | optional | True |
 | <a name="py_related_rule-first"></a>first |  this is the first doc string!   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |

--- a/test/testdata/repo_rules_test/golden.md
+++ b/test/testdata/repo_rules_test/golden.md
@@ -14,7 +14,7 @@ Minimal example of a repository rule.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="my_repo-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="my_repo-useless"></a>useless |  This argument will be ingored. You don't have to specify it, but you may.   | String | optional | "ignoreme" |
 

--- a/test/testdata/same_level_file_test/golden.md
+++ b/test/testdata/same_level_file_test/golden.md
@@ -14,7 +14,7 @@ This is my rule. It does stuff.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="my_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="my_rule-first"></a>first |  first my_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a name="my_rule-second"></a>second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |

--- a/test/testdata/simple_test/golden.md
+++ b/test/testdata/simple_test/golden.md
@@ -14,7 +14,7 @@ This is my rule. It does stuff.
 
 
 | Name  | Description | Type | Mandatory | Default |
-| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a name="my_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a name="my_rule-first"></a>first |  first doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a name="my_rule-fourth"></a>fourth |  fourth doc string   | Boolean | optional | False |

--- a/test/testdata/struct_default_value_test/golden.md
+++ b/test/testdata/struct_default_value_test/golden.md
@@ -15,7 +15,7 @@ Checks the default values of structs.
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="check_struct_default_values-struct_no_args"></a>struct_no_args |  struct with no arguments   |  <code>struct()</code> |
 | <a name="check_struct_default_values-struct_arg"></a>struct_arg |  struct with one argument   |  <code>struct(foo = "bar")</code> |
 | <a name="check_struct_default_values-struct_args"></a>struct_args |  struct with multiple arguments   |  <code>struct(bar = "foo", foo = "bar")</code> |

--- a/test/testdata/unknown_name_test/golden.md
+++ b/test/testdata/unknown_name_test/golden.md
@@ -14,7 +14,7 @@ my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 
 
 | Name  | Description | Default Value |
-| :-------------: | :-------------: | :-------------: |
+| :------------- | :------------- | :------------- |
 | <a name="my_rule_impl-ctx"></a>ctx |  <p align="center"> - </p>   |  none |
 
 


### PR DESCRIPTION
Attribute descriptions tend to get pretty long and read better when left-aligned.