### PR TITLE
Modify HTML table templates to be GFM-friendly

### DIFF
--- a/stardoc/templates/html_tables/aspect.vm
+++ b/stardoc/templates/html_tables/aspect.vm
@@ -22,12 +22,12 @@ $aspectInfo.getDocString()
 <td><code>${aspectAttribute}</code></td>
 <td>
 String; required.
-#end
 </td>
 </tr>
 #end
 </tbody>
 </table>
+#end
 
 #[[###]]# Attributes
 

--- a/stardoc/templates/html_tables/aspect.vm
+++ b/stardoc/templates/html_tables/aspect.vm
@@ -12,45 +12,49 @@ $aspectInfo.getDocString()
 
 #if (!$aspectInfo.getAspectAttributeList().isEmpty())
 <table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
 #foreach ($aspectAttribute in $aspectInfo.getAspectAttributeList())
-    <tr id="${aspectName}-${aspectAttribute}">
-      <td><code>${aspectAttribute}</code></td>
-      <td>
-        String; required.
+<tr id="${aspectName}-${aspectAttribute}">
+<td><code>${aspectAttribute}</code></td>
+<td>
+String; required.
 #end
-      </td>
-    </tr>
+</td>
+</tr>
 #end
-  </tbody>
+</tbody>
 </table>
 
 #[[###]]# Attributes
 
 #if (!$aspectInfo.getAttributeList().isEmpty())
 <table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
 #foreach ($attribute in $aspectInfo.getAttributeList())
-    <tr id="${aspectName}-${attribute.name}">
-      <td><code>${attribute.name}</code></td>
-      <td>
-        ${util.attributeTypeString($attribute)}; ${util.mandatoryString($attribute)}
+<tr id="${aspectName}-${attribute.name}">
+<td><code>${attribute.name}</code></td>
+<td>
+
+${util.attributeTypeString($attribute)}; ${util.mandatoryString($attribute)}
+
 #if (!$attribute.docString.isEmpty())
-        <p>
-          ${attribute.docString.trim()}
-        </p>
+<p>
+
+${attribute.docString.trim()}
+
+</p>
 #end
-      </td>
-    </tr>
+</td>
+</tr>
 #end
-  </tbody>
+</tbody>
 </table>
 #end

--- a/stardoc/templates/html_tables/func.vm
+++ b/stardoc/templates/html_tables/func.vm
@@ -22,7 +22,10 @@ ${util.htmlEscape($funcInfo.docString)}
 <td><code>${param.name}</code></td>
 <td>
 
-${util.mandatoryString($param)}.#if(!$param.getDefaultValue().isEmpty()) default is <code>$param.getDefaultValue()</code>#end
+${util.mandatoryString($param)}.
+#if(!$param.getDefaultValue().isEmpty())
+default is <code>$param.getDefaultValue()</code>
+#end
 
 #if (!$param.docString.isEmpty())
 <p>

--- a/stardoc/templates/html_tables/func.vm
+++ b/stardoc/templates/html_tables/func.vm
@@ -12,25 +12,28 @@ ${util.htmlEscape($funcInfo.docString)}
 #[[###]]# Parameters
 
 <table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
 #foreach ($param in $funcInfo.getParameterList())
-    <tr id="${funcInfo.functionName}-${param.name}">
-      <td><code>${param.name}</code></td>
-      <td>
-        ${util.mandatoryString($param)}.#if(!$param.getDefaultValue().isEmpty()) default is <code>$param.getDefaultValue()</code>#end
+<tr id="${funcInfo.functionName}-${param.name}">
+<td><code>${param.name}</code></td>
+<td>
+
+${util.mandatoryString($param)}.#if(!$param.getDefaultValue().isEmpty()) default is <code>$param.getDefaultValue()</code>#end
 
 #if (!$param.docString.isEmpty())
-        <p>
-          ${param.docString.trim()}
-        </p>
+<p>
+
+${param.docString.trim()}
+
+</p>
 #end
-      </td>
-    </tr>
+</td>
+</tr>
 #end
-  </tbody>
+</tbody>
 </table>
 #end

--- a/stardoc/templates/html_tables/provider.vm
+++ b/stardoc/templates/html_tables/provider.vm
@@ -12,19 +12,23 @@ ${util.htmlEscape($providerInfo.docString)}
 #[[###]]# Fields
 
 <table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
 #foreach ($field in $providerInfo.fieldInfoList)
-    <tr id="${providerName}-${field.name}">
-      <td><code>${field.name}</code></td>
-      <td>
-        <p>${field.docString}</p>
-      </td>
-    </tr>
+<tr id="${providerName}-${field.name}">
+<td><code>${field.name}</code></td>
+<td>
+<p>
+
+${field.docString}
+
+</p>
+</td>
+</tr>
 #end
-  </tbody>
+</tbody>
 </table>
 #end

--- a/stardoc/templates/html_tables/rule.vm
+++ b/stardoc/templates/html_tables/rule.vm
@@ -25,9 +25,11 @@ ${util.htmlEscape($ruleInfo.docString)}
 ${util.attributeTypeString($attribute)}; ${util.mandatoryString($attribute)}
 
 #if (!$attribute.docString.isEmpty())
+<p>
 
 ${attribute.docString.trim()}
 
+</p>
 #end
 #if (!$attribute.getProviderNameGroupList().isEmpty())
 <p>

--- a/stardoc/templates/html_tables/rule.vm
+++ b/stardoc/templates/html_tables/rule.vm
@@ -12,29 +12,33 @@ ${util.htmlEscape($ruleInfo.docString)}
 
 #if (!$ruleInfo.getAttributeList().isEmpty())
 <table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
 #foreach ($attribute in $ruleInfo.getAttributeList())
-    <tr id="${ruleName}-${attribute.name}">
-      <td><code>${attribute.name}</code></td>
-      <td>
-        ${util.attributeTypeString($attribute)}; ${util.mandatoryString($attribute)}
+<tr id="${ruleName}-${attribute.name}">
+<td><code>${attribute.name}</code></td>
+<td>
+
+${util.attributeTypeString($attribute)}; ${util.mandatoryString($attribute)}
+
 #if (!$attribute.docString.isEmpty())
-        <p>
-          ${attribute.docString.trim()}
-        </p>
+
+${attribute.docString.trim()}
+
 #end
 #if (!$attribute.getProviderNameGroupList().isEmpty())
-        <p>
-          The dependencies of this attribute must provide: ${util.attributeProviders($attribute)}
-        </p>
+<p>
+
+The dependencies of this attribute must provide: ${util.attributeProviders($attribute)}
+
+</p>
 #end
-      </td>
-    </tr>
+</td>
+</tr>
 #end
-  </tbody>
+</tbody>
 </table>
 #end

--- a/test/testdata/html_tables_template_test/golden.md
+++ b/test/testdata/html_tables_template_test/golden.md
@@ -13,36 +13,46 @@ Small example of rule using a markdown template.
 ### Attributes
 
 <table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="example_rule-name">
-      <td><code>name</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
-        <p>
-          A unique name for this target.
-        </p>
-      </td>
-    </tr>
-    <tr id="example_rule-first">
-      <td><code>first</code></td>
-      <td>
-        String; optional
-        <p>
-          This is the first attribute
-        </p>
-      </td>
-    </tr>
-    <tr id="example_rule-second">
-      <td><code>second</code></td>
-      <td>
-        String; optional
-      </td>
-    </tr>
-  </tbody>
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="example_rule-name">
+<td><code>name</code></td>
+<td>
+
+<a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
+
+<p>
+
+A unique name for this target.
+
+</p>
+</td>
+</tr>
+<tr id="example_rule-first">
+<td><code>first</code></td>
+<td>
+
+String; optional
+
+<p>
+
+This is the first attribute
+
+</p>
+</td>
+</tr>
+<tr id="example_rule-second">
+<td><code>second</code></td>
+<td>
+
+String; optional
+
+</td>
+</tr>
+</tbody>
 </table>
 
 
@@ -59,30 +69,42 @@ Small example of provider using a markdown template.
 ### Fields
 
 <table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="ExampleProviderInfo-foo">
-      <td><code>foo</code></td>
-      <td>
-        <p>A string representing foo</p>
-      </td>
-    </tr>
-    <tr id="ExampleProviderInfo-bar">
-      <td><code>bar</code></td>
-      <td>
-        <p>A string representing bar</p>
-      </td>
-    </tr>
-    <tr id="ExampleProviderInfo-baz">
-      <td><code>baz</code></td>
-      <td>
-        <p>A string representing baz</p>
-      </td>
-    </tr>
-  </tbody>
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="ExampleProviderInfo-foo">
+<td><code>foo</code></td>
+<td>
+<p>
+
+A string representing foo
+
+</p>
+</td>
+</tr>
+<tr id="ExampleProviderInfo-bar">
+<td><code>bar</code></td>
+<td>
+<p>
+
+A string representing bar
+
+</p>
+</td>
+</tr>
+<tr id="ExampleProviderInfo-baz">
+<td><code>baz</code></td>
+<td>
+<p>
+
+A string representing baz
+
+</p>
+</td>
+</tr>
+</tbody>
 </table>
 
 
@@ -99,30 +121,39 @@ Small example of function using a markdown template.
 ### Parameters
 
 <table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="example_function-foo">
-      <td><code>foo</code></td>
-      <td>
-        required.
-        <p>
-          This parameter does foo related things.
-        </p>
-      </td>
-    </tr>
-    <tr id="example_function-bar">
-      <td><code>bar</code></td>
-      <td>
-        optional. default is <code>"bar"</code>
-        <p>
-          This parameter does bar related things.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="example_function-foo">
+<td><code>foo</code></td>
+<td>
+
+required.
+
+<p>
+
+This parameter does foo related things.
+
+</p>
+</td>
+</tr>
+<tr id="example_function-bar">
+<td><code>bar</code></td>
+<td>
+
+optional.
+default is <code>"bar"</code>
+
+<p>
+
+This parameter does bar related things.
+
+</p>
+</td>
+</tr>
+</tbody>
 </table>
 
 
@@ -139,57 +170,69 @@ Small example of aspect using a markdown template.
 ### Aspect Attributes
 
 <table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="example_aspect-deps">
-      <td><code>deps</code></td>
-      <td>
-        String; required.
-    <tr id="example_aspect-attr_aspect">
-      <td><code>attr_aspect</code></td>
-      <td>
-        String; required.
-      </td>
-    </tr>
-  </tbody>
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="example_aspect-deps">
+<td><code>deps</code></td>
+<td>
+String; required.
+</td>
+</tr>
+<tr id="example_aspect-attr_aspect">
+<td><code>attr_aspect</code></td>
+<td>
+String; required.
+</td>
+</tr>
+</tbody>
 </table>
 
 ### Attributes
 
 <table class="params-table">
-  <colgroup>
-    <col class="col-param" />
-    <col class="col-description" />
-  </colgroup>
-  <tbody>
-    <tr id="example_aspect-name">
-      <td><code>name</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
-        <p>
-          A unique name for this target.
-        </p>
-      </td>
-    </tr>
-    <tr id="example_aspect-first">
-      <td><code>first</code></td>
-      <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
-      </td>
-    </tr>
-    <tr id="example_aspect-second">
-      <td><code>second</code></td>
-      <td>
-        String; optional
-        <p>
-          This is the second attribute.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+<tr id="example_aspect-name">
+<td><code>name</code></td>
+<td>
+
+<a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
+
+<p>
+
+A unique name for this target.
+
+</p>
+</td>
+</tr>
+<tr id="example_aspect-first">
+<td><code>first</code></td>
+<td>
+
+<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
+
+</td>
+</tr>
+<tr id="example_aspect-second">
+<td><code>second</code></td>
+<td>
+
+String; optional
+
+<p>
+
+This is the second attribute.
+
+</p>
+</td>
+</tr>
+</tbody>
 </table>
 
 


### PR DESCRIPTION
GitHub flavored markdown permits markdown within HTML tags such as `<table>`, `<td>`, etc, as long as the HTML tags are 1) not indented more than 3 spaces and 2) are separated from the markdown by an empty line. (For the exact parsing rules see https://github.github.com/gfm/#html-blocks).