### PR TITLE
Fix compilation of Stardoc, broken by Bazel 3.4

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,8 +13,25 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 # Needed for generating the Stardoc release binary.
 git_repository(
     name = "io_bazel",
-    commit = "5eeccd8a647df10d154d3b86e9732e7f263c96db",  # Oct 7, 2019
+    commit = "b2b9fa00d7d168e9553cfc9fe381928e8e246176",  # 2020-07-28
     remote = "https://github.com/bazelbuild/bazel.git",
+    shallow_since = "1595950714 -0700",
+)
+
+# The following binds are needed for building protobuf java libraries.
+bind(
+    name = "guava",
+    actual = "@io_bazel//third_party:guava",
+)
+
+bind(
+    name = "gson",
+    actual = "@io_bazel//third_party:gson",
+)
+
+bind(
+    name = "error_prone_annotations",
+    actual = "@io_bazel//third_party:error_prone_annotations",
 )
 
 # Needed only because of java_tools.
@@ -26,13 +43,6 @@ http_archive(
         "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
         "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
     ],
-)
-
-# Needed as a transitive dependency of @io_bazel
-git_repository(
-    name = "com_google_protobuf",
-    commit = "7b28271a61a3da0a37f6fda399b0c4c86464e5b3",  # 2018-11-16
-    remote = "https://github.com/protocolbuffers/protobuf.git",
 )
 
 # Needed as a transitive dependency of @io_bazel
@@ -68,3 +78,9 @@ local_repository(
     name = "local_repository_test",
     path = "test/testdata/local_repository_test",
 )
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()

--- a/test/testdata/attribute_types_test/golden.md
+++ b/test/testdata/attribute_types_test/golden.md
@@ -22,8 +22,8 @@ This is my rule. It does stuff.
 | <a id="my_rule-d"></a>d |  Some label   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="my_rule-e"></a>e |  Some label_keyed_string_dict   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | required |  |
 | <a id="my_rule-f"></a>f |  Some label_list   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
-| <a id="my_rule-g"></a>g |  Some output   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="my_rule-h"></a>h |  Some output_list   | List of labels | optional | None |
+| <a id="my_rule-g"></a>g |  Some output   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |  |
+| <a id="my_rule-h"></a>h |  Some output_list   | List of labels | optional |  |
 | <a id="my_rule-i"></a>i |  Some string   | String | required |  |
 | <a id="my_rule-j"></a>j |  Some string_dict   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 | <a id="my_rule-k"></a>k |  Some string_list   | List of strings | required |  |

--- a/test/testdata/filter_rules_test/input.bzl
+++ b/test/testdata/filter_rules_test/input.bzl
@@ -1,7 +1,6 @@
 # buildifier: disable=module-docstring
 load(
     ":testdata/filter_rules_test/dep.bzl",
-    "my_rule_impl",
     dep_rule = "my_rule",
 )
 

--- a/test/testdata/py_rule_test/golden.md
+++ b/test/testdata/py_rule_test/golden.md
@@ -20,7 +20,7 @@ This rule does python-related things.
 | <a id="py_related_rule-first"></a>first |  this is the first doc string!   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="py_related_rule-fourth"></a>fourth |  the fourth doc string.   | Boolean | optional | False |
 | <a id="py_related_rule-second"></a>second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
-| <a id="py_related_rule-sixth"></a>sixth |  it's the sixth thing.   | List of integers | optional | range(0, 10) |
+| <a id="py_related_rule-sixth"></a>sixth |  it's the sixth thing.   | List of integers | optional | [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] |
 | <a id="py_related_rule-third"></a>third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 

--- a/test/testdata/repo_rules_test/golden.md
+++ b/test/testdata/repo_rules_test/golden.md
@@ -5,7 +5,7 @@
 ## my_repo
 
 <pre>
-my_repo(<a href="#my_repo-name">name</a>, <a href="#my_repo-useless">useless</a>)
+my_repo(<a href="#my_repo-name">name</a>, <a href="#my_repo-repo_mapping">repo_mapping</a>, <a href="#my_repo-useless">useless</a>)
 </pre>
 
 Minimal example of a repository rule.
@@ -16,6 +16,7 @@ Minimal example of a repository rule.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="my_repo-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="my_repo-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 | <a id="my_repo-useless"></a>useless |  This argument will be ingored. You don't have to specify it, but you may.   | String | optional | "ignoreme" |
 
 


### PR DESCRIPTION
Bazel 3.4 has a change in error prone that broke the compilation. This PR
updates the io_bazel dependency. I had to update a few other things to
get the tests passing.