### PR TITLE
Update Skylib dependency

### DIFF
--- a/setup.bzl
+++ b/setup.bzl
@@ -25,8 +25,9 @@ def stardoc_repositories():
     _include_if_not_defined(
         http_archive,
         name = "bazel_skylib",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz"],
-        sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/16de038c484145363340eeaf0e97a0c9889a931b.tar.gz"], # 2020-08-11
+        sha256 = "96e0cd3f731f0caef9e9919aa119ecc6dace36b149c2f47e40aa50587790402b",
+        strip_prefix = "bazel-skylib-16de038c484145363340eeaf0e97a0c9889a931b",
     )
     _include_if_not_defined(
         http_archive,


### PR DESCRIPTION
The update includes a fix for the flag --incompatible_disable_depset_items.