### PR TITLE
Update repository name to match documentation

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "io_bazel_skydoc")
+workspace(name = "io_bazel_stardoc")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(":setup.bzl", "stardoc_repositories")

--- a/test/testdata/local_repository_test/BUILD
+++ b/test/testdata/local_repository_test/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -23,6 +23,6 @@ bzl_library(
     name = "lib",
     srcs = [
         "input.bzl",
-        "@io_bazel_skydoc//test:testdata/fakedeps/dep.bzl",
+        "@io_bazel_stardoc//test:testdata/fakedeps/dep.bzl",
     ],
 )

--- a/test/testdata/local_repository_test/input.bzl
+++ b/test/testdata/local_repository_test/input.bzl
@@ -1,6 +1,6 @@
 """A test that verifies documenting functions in an input file under a local_repository."""
 
-load("@io_bazel_skydoc//test/testdata/fakedeps:dep.bzl", "give_me_five")
+load("@io_bazel_stardoc//test/testdata/fakedeps:dep.bzl", "give_me_five")
 
 def min(integers):
     """Returns the minimum of given elements.


### PR DESCRIPTION
Documentation [here](https://github.com/bazelbuild/stardoc/blob/master/docs/getting_started_stardoc.md#setup) mentions this repo being loaded as `io_bazel_stardoc` whereas the real repo name is `io_bazel_skydoc`.