### PR TITLE
Add bzl_library for html_tables_stardoc.bzl

### DIFF
--- a/stardoc/BUILD
+++ b/stardoc/BUILD
@@ -26,6 +26,15 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "html_tables_stardoc",
+    srcs = ["html_tables_stardoc.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":stardoc_lib",
+    ],
+)
+
 stardoc(
     name = "stardoc_doc",
     out = "stardoc_doc.md",


### PR DESCRIPTION
Previously, there wasn't any `bzl_library` which included it. Which prevents further downstream `bzl_library`s from being defined with fully accurate deps.