### PR TITLE
Add distro tarball generation and maintainer docs for cutting a release

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,10 +1,38 @@
 licenses(["notice"])
 
-exports_files(["LICENSE"])
+exports_files([
+    "LICENSE",
+    "WORKSPACE",
+])
 
 filegroup(
     name = "stardoc_rule_doc",
     testonly = 1,
     srcs = ["docs/stardoc_rule.md"],
     visibility = ["//test:__pkg__"],
+)
+
+# Sources needed for release tarball.
+filegroup(
+    name = "distro_srcs",
+    srcs = [
+        "AUTHORS",
+        "BUILD",
+        "CHANGELOG.md",
+        "CODEOWNERS",
+        "CONTRIBUTORS",
+        "LICENSE",
+        "//stardoc:distro_srcs",
+        "//stardoc/proto:distro_srcs",
+    ] + glob(["*.bzl"]),
+    visibility = ["//:__subpackages__"],
+)
+
+# Binaries needed for release tarball.
+filegroup(
+    name = "distro_bins",
+    srcs = [
+        "//stardoc:distro_bins",
+    ],
+    visibility = ["//:__subpackages__"],
 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+## Release 0.5.0
+
+This release includes many fixes for Stardoc's markdown output, plus:
+
+**New Features**
+
+-   Raw protobuf output via `format = "proto"` (#20)
+-   Stardoc now outputs documentation for macro returns and deprecations (#75)
+    as well as module (file) docstrings (#100)
+
+**Contributors**
+
+Alexandre Rostovtsev, Alex Eagle, Andrew Z Allen, Chris Rebert, c-parsons, Ivo
+List, Jon Brandvein, Laurent Le Brun, Max Vorobev, pbatg, Philipp Wollermann,
+Samuel Giddins, Thomas Van Lenten, Tiago Quelhas, Xùdōng Yáng, Yiting Wang
+
+## Release 0.4.0
+
+First release of **Stardoc** under the new repository location
+[bazelbuild/stardoc](https://github.com/bazelbuild/stardoc). Please use this
+repository for future Stardoc releases instead of its old location. See
+[Getting Started](https://github.com/bazelbuild/stardoc/blob/4378e9b6bb2831de7143580594782f538f461180/docs/getting_started_stardoc.md)
+for updated setup information.
+
+There are **many** new features since the last release. A summary of major
+features:
+
+-   Changed the default Stardoc output format to use pure-markdown tables
+    instead of HTML tables. This output format is fully compatible with markdown
+    formatting constructs. For example, use `**bold**` instead of `<b>bold</b>`.
+    The `<`. and `>` characters are escaped in this output format.
+-   Stardoc now supports custom formatting. See
+    [Custom Output documentation](https://github.com/bazelbuild/stardoc/blob/4378e9b6bb2831de7143580594782f538f461180/docs/advanced_stardoc_usage.md#custom-output)
+    for details.
+-   `aspect()` definitions are now documented by Stardoc.
+-   Module definitions (structs which combine series of functions in a
+    'namespace') are now documetned by Stardoc.
+-   Attribute default-value information is now included in output.
+
+**Huge Thanks to [kendalllaneee](https://github.com/kendalllaneee) and
+[blossommojekwu](https://github.com/blossommojekwu) for their work on many of
+the features in this release.**
+

--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ details on the deprecation and migration details.
 ### Future plans
 
 See our [future plans](docs/future_plans.md) for refactoring Stardoc to be more consistent with how Bazel evaluates .bzl files, and what it means for maintenance of this project.
+
+### Maintainer's guide
+
+See the [maintaner's guide](docs/maintainers_guide.md) for instructions for
+cutting a new release.
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,9 +5,10 @@ load(":setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
 
-#######################################################################
-##### MOST USERS SHOULD NOT NEED TO COPY ANYTHING BELOW THIS LINE #####
-#######################################################################
+### INTERNAL ONLY - lines after this are not included in the release packaging.
+#
+# Include dependencies which are only needed for development of Stardoc here.
+
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 # Needed for generating the Stardoc release binary.
@@ -53,15 +54,18 @@ git_repository(
     shallow_since = "1564776078 -0400",
 )
 
-# Needed as a transitive dependency of @io_bazel
+# Needed for //distro:__pkg__ and as a transitive dependency of @io_bazel
 http_archive(
     name = "rules_pkg",
-    sha256 = "5bdc04987af79bd27bc5b00fe30f59a858f77ffa0bd2d8143d5b31ad8b1bd71c",
+    sha256 = "a89e203d3cf264e564fcb96b6e06dd70bc0557356eb48400ce4b5d97c2c3720d",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/rules_pkg-0.2.0.tar.gz",
-        "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.0/rules_pkg-0.2.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
     ],
 )
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()
 
 # Needed as a transitive dependency of @io_bazel
 http_archive(

--- a/distro/BUILD
+++ b/distro/BUILD
@@ -1,0 +1,54 @@
+load("@io_bazel_stardoc//:version.bzl", "version")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+package(
+    default_visibility = ["//visibility:private"],
+)
+
+alias(
+    name = "distro",
+    actual = "stardoc-%s" % version,
+)
+
+genrule(
+    name = "distro_workspace",
+    srcs = ["//:WORKSPACE"],
+    outs = ["WORKSPACE"],
+    cmd = "sed -e '/### INTERNAL ONLY/,$$d' $(location //:WORKSPACE) >$@",
+)
+
+pkg_tar(
+    name = "distro_srcs",
+    srcs = [
+        "distro_workspace",
+        "//:distro_srcs",
+    ],
+    mode = "0644",
+    # Make it owned by root so it does not have the uid of the CI robot.
+    owner = "0.0",
+    package_dir = "",
+    strip_prefix = ".",
+)
+
+pkg_tar(
+    name = "distro_bins",
+    srcs = ["//:distro_bins"],
+    mode = "0755",
+    # Make it owned by root so it does not have the uid of the CI robot.
+    owner = "0.0",
+    package_dir = "",
+    strip_prefix = ".",
+)
+
+# Build the artifact to put on the github release page.
+pkg_tar(
+    name = "stardoc-%s" % version,
+    extension = "tar.gz",
+    # Make it owned by root so it does not have the uid of the CI robot.
+    owner = "0.0",
+    strip_prefix = ".",
+    deps = [
+        ":distro_bins.tar",
+        ":distro_srcs.tar",
+    ],
+)

--- a/docs/getting_started_stardoc.md
+++ b/docs/getting_started_stardoc.md
@@ -12,23 +12,16 @@ extensions](https://www.bazel.build/docs/skylark/concepts.html)
 
 ## Setup
 
-To use Stardoc, add the following to your `WORKSPACE` file:
+Edit your `WORKSPACE` file as shown in the `WORKSPACE` setup section for
+[the current Stardoc release](https://github.com/bazelbuild/stardoc/releases).
+
+Then add
 
 ```python
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
-    name = "io_bazel_stardoc",
-    remote = "https://github.com/bazelbuild/stardoc.git",
-    tag = "0.4.0",
-)
-
-load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
-stardoc_repositories()
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 ```
 
-The load statement and function call after the `io_bazel_stardoc` repository
-definition ensure that this repository's dependencies are loaded.
+to your `BUILD` or .bzl file to start using the `stardoc` rule.
 
 ## Next Steps
 

--- a/docs/maintainers_guide.md
+++ b/docs/maintainers_guide.md
@@ -1,0 +1,91 @@
+# Stardoc Maintainer's Guide
+
+## Updating Jars
+
+Stardoc's source code currently lives in the Bazel source tree at
+https://github.com/bazelbuild/bazel/tree/master/src/main/java/com/google/devtools/build/skydoc
+
+For simplicity of use and building, Stardoc bundles two pre-built jars built
+from Bazel source: `stardoc_binary.jar` (emits protobuf documentation format)
+and `renderer_binary.jar` (turns the protobuf into markdown).
+
+To update the jars:
+
+1.  Update `io_bazel` repo commit in `WORKSPACE`. Update transitive deps in
+    `WORKSPACE` as needed.
+2.  run `update-release-binary.sh`
+
+## Making a New Release
+
+1.  Update CHANGELOG.md at the top. You may want to use the following template:
+
+--------------------------------------------------------------------------------
+
+## Release $VERSION
+
+**New Features**
+
+-   Feature
+-   Feature
+
+**Incompatible Changes**
+
+-   Change
+-   Change
+
+**Contributors**
+
+Name 1, Name 2, Name 3 (alphabetically)
+
+--------------------------------------------------------------------------------
+
+2.  Bump `version` in version.bzl to the new version.
+3.  Ensure that the commits for steps 1 and 2 have been merged. All further
+    steps must be performed on a single, known-good git commit.
+4.  `bazel build //distro`
+5.  Copy the `stardoc-$VERSION.tar.gz` tarball to the mirror (you'll need Bazel
+    developer gcloud credentials; assuming you are a Bazel developer, you can
+    obtain them via `gcloud init`):
+
+```
+gsutil cp bazel-bin/distro/stardoc-$VERSION.tar.gz gs://bazel-mirror/github.com/bazelbuild/stardoc/releases/download/$VERSION/stardoc-$VERSION.tar.gz
+gsutil setmeta -h "Cache-Control: public, max-age=31536000" "gs://bazel-mirror/github.com/bazelbuild/stardoc/releases/download/$VERSION/stardoc-$VERSION.tar.gz"
+```
+
+6.  Run `sha256sum bazel-bin/distro/stardoc-$VERSION.tar.gz`; you'll need the
+    checksum for the release notes.
+7.  Draft a new release with a new tag named $VERSION in github. Attach
+    `stardoc-$VERSION.tar.gz` to the release. For the release notes, use the
+    CHANGELOG.md entry plus the following template:
+
+--------------------------------------------------------------------------------
+
+**WORKSPACE setup**
+
+To use Stardoc, add the following to your `WORKSPACE` file:
+
+```
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_stardoc",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/$VERSION/stardoc-$VERSION.tar.gz",
+        "https://github.com/bazelbuild/stardoc/releases/download/$VERSION/stardoc-$VERSION.tar.gz",
+    ],
+    sha256 = "$SHA256SUM",
+)
+
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+stardoc_repositories()
+```
+
+The load statement and function call after the `io_bazel_stardoc` repository
+definition ensure that this repository's dependencies are loaded.
+
+**Using the rules**
+
+See [the source](https://github.com/bazelbuild/stardoc/tree/$VERSION).
+
+--------------------------------------------------------------------------------
+

--- a/stardoc/BUILD
+++ b/stardoc/BUILD
@@ -88,3 +88,23 @@ java_import(
     jars = ["renderer_binary.jar"],
     visibility = ["//visibility:private"],
 )
+
+# Sources needed for release tarball.
+filegroup(
+    name = "distro_srcs",
+    srcs = [
+        "BUILD",
+    ] + glob([
+        "*.bzl",
+        "*.jar",
+        "templates/**",
+    ]),
+    visibility = ["//:__pkg__"],
+)
+
+# Binaries needed for release tarball.
+filegroup(
+    name = "distro_bins",
+    srcs = glob(["*.jar"]),
+    visibility = ["//:__pkg__"],
+)

--- a/stardoc/proto/BUILD
+++ b/stardoc/proto/BUILD
@@ -3,3 +3,12 @@ licenses(["notice"])
 package(default_visibility = ["//visibility:public"])
 
 exports_files(["stardoc_output.proto"])
+
+# Sources needed for release tarball.
+filegroup(
+    name = "distro_srcs",
+    srcs = [
+        "BUILD",
+    ] + glob(["*.proto"]),
+    visibility = ["//:__pkg__"],
+)

--- a/version.bzl
+++ b/version.bzl
@@ -1,0 +1,16 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The version of Stardoc."""
+
+version = "0.5.0"


### PR DESCRIPTION
We want to provide a distributable release tarball (without test-only deps or
code) for users who are only using Stardoc, not developing it.