### PR TITLE
Fix the generated links to things with CamelCase names

### DIFF
--- a/docs/stardoc_rule.md
+++ b/docs/stardoc_rule.md
@@ -2,7 +2,7 @@
 
 Starlark rule for stardoc: a documentation generator tool written in Java.
 
-<a id="#stardoc"></a>
+<a id="stardoc"></a>
 
 ## stardoc
 

--- a/stardoc/templates/html_tables/aspect.vm
+++ b/stardoc/templates/html_tables/aspect.vm
@@ -1,4 +1,4 @@
-<a id="#${aspectName}"></a>
+<a id="${aspectName}"></a>
 
 #[[##]]# ${aspectName}
 

--- a/stardoc/templates/html_tables/func.vm
+++ b/stardoc/templates/html_tables/func.vm
@@ -1,4 +1,4 @@
-<a id="#${funcInfo.functionName}"></a>
+<a id="${funcInfo.functionName}"></a>
 
 #[[##]]# ${funcInfo.functionName}
 

--- a/stardoc/templates/html_tables/provider.vm
+++ b/stardoc/templates/html_tables/provider.vm
@@ -1,4 +1,4 @@
-<a id="#${providerName}"></a>
+<a id="${providerName}"></a>
 
 #[[##]]# ${providerName}
 

--- a/stardoc/templates/html_tables/rule.vm
+++ b/stardoc/templates/html_tables/rule.vm
@@ -1,4 +1,4 @@
-<a id="#${ruleName}"></a>
+<a id="${ruleName}"></a>
 
 #[[##]]# ${ruleName}
 

--- a/stardoc/templates/markdown_tables/aspect.vm
+++ b/stardoc/templates/markdown_tables/aspect.vm
@@ -1,4 +1,4 @@
-<a id="#${aspectName}"></a>
+<a id="${aspectName}"></a>
 
 #[[##]]# ${aspectName}
 

--- a/stardoc/templates/markdown_tables/func.vm
+++ b/stardoc/templates/markdown_tables/func.vm
@@ -1,4 +1,4 @@
-<a id="#${funcInfo.functionName}"></a>
+<a id="${funcInfo.functionName}"></a>
 
 #[[##]]# ${funcInfo.functionName}
 

--- a/stardoc/templates/markdown_tables/provider.vm
+++ b/stardoc/templates/markdown_tables/provider.vm
@@ -1,4 +1,4 @@
-<a id="#${providerName}"></a>
+<a id="${providerName}"></a>
 
 #[[##]]# ${providerName}
 

--- a/stardoc/templates/markdown_tables/rule.vm
+++ b/stardoc/templates/markdown_tables/rule.vm
@@ -1,4 +1,4 @@
-<a id="#${ruleName}"></a>
+<a id="${ruleName}"></a>
 
 #[[##]]# ${ruleName}
 

--- a/test/testdata/android_basic_test/golden.md
+++ b/test/testdata/android_basic_test/golden.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#android_related_rule"></a>
+<a id="android_related_rule"></a>
 
 ## android_related_rule
 

--- a/test/testdata/angle_bracket_test/golden.md
+++ b/test/testdata/angle_bracket_test/golden.md
@@ -2,7 +2,7 @@
 
 Input file to test angle bracket bug (https://github.com/bazelbuild/skydoc/issues/186)
 
-<a id="#my_anglebrac"></a>
+<a id="my_anglebrac"></a>
 
 ## my_anglebrac
 
@@ -21,7 +21,7 @@ Rule with <brackets>
 | <a id="my_anglebrac-useless"></a>useless |  Args with some tags: &lt;tag1&gt;, &lt;tag2&gt;   | String | optional | "Find <brackets>" |
 
 
-<a id="#bracketuse"></a>
+<a id="bracketuse"></a>
 
 ## bracketuse
 
@@ -41,7 +41,7 @@ Information with <brackets>
 | <a id="bracketuse-baz"></a>baz |  A string representing baz    |
 
 
-<a id="#bracket_function"></a>
+<a id="bracket_function"></a>
 
 ## bracket_function
 

--- a/test/testdata/apple_basic_test/golden.md
+++ b/test/testdata/apple_basic_test/golden.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#apple_related_rule"></a>
+<a id="apple_related_rule"></a>
 
 ## apple_related_rule
 

--- a/test/testdata/aspect_test/golden.md
+++ b/test/testdata/aspect_test/golden.md
@@ -2,7 +2,7 @@
 
 The input file for the aspect test
 
-<a id="#my_aspect_impl"></a>
+<a id="my_aspect_impl"></a>
 
 ## my_aspect_impl
 
@@ -20,7 +20,7 @@ my_aspect_impl(<a href="#my_aspect_impl-ctx">ctx</a>)
 | <a id="my_aspect_impl-ctx"></a>ctx |  <p align="center"> - </p>   |  none |
 
 
-<a id="#my_aspect"></a>
+<a id="my_aspect"></a>
 
 ## my_aspect
 
@@ -49,7 +49,7 @@ This is my aspect. It does stuff.
 | <a id="my_aspect-second"></a>second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |   |
 
 
-<a id="#other_aspect"></a>
+<a id="other_aspect"></a>
 
 ## other_aspect
 

--- a/test/testdata/attribute_defaults_test/golden.md
+++ b/test/testdata/attribute_defaults_test/golden.md
@@ -2,7 +2,7 @@
 
 A golden test to verify attribute default values.
 
-<a id="#my_rule"></a>
+<a id="my_rule"></a>
 
 ## my_rule
 
@@ -43,7 +43,7 @@ This is my rule. It does stuff.
 | <a id="my_rule-w"></a>w |  -   | Integer | optional | 0 |
 
 
-<a id="#my_aspect"></a>
+<a id="my_aspect"></a>
 
 ## my_aspect
 

--- a/test/testdata/attribute_types_test/golden.md
+++ b/test/testdata/attribute_types_test/golden.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#my_rule"></a>
+<a id="my_rule"></a>
 
 ## my_rule
 

--- a/test/testdata/cc_api_test/golden.md
+++ b/test/testdata/cc_api_test/golden.md
@@ -2,7 +2,7 @@
 
 Input file for C++ api test
 
-<a id="#cpp_related_rule"></a>
+<a id="cpp_related_rule"></a>
 
 ## cpp_related_rule
 
@@ -24,7 +24,7 @@ This rule does C++-related things.
 | <a id="cpp_related_rule-third"></a>third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
-<a id="#exercise_the_api"></a>
+<a id="exercise_the_api"></a>
 
 ## exercise_the_api
 
@@ -36,7 +36,7 @@ exercise_the_api()
 
 
 
-<a id="#my_rule_impl"></a>
+<a id="my_rule_impl"></a>
 
 ## my_rule_impl
 

--- a/test/testdata/config_apis_test/golden.md
+++ b/test/testdata/config_apis_test/golden.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#int_setting"></a>
+<a id="int_setting"></a>
 
 ## int_setting
 
@@ -20,7 +20,7 @@ An integer flag.
 | <a id="int_setting-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
-<a id="#string_flag"></a>
+<a id="string_flag"></a>
 
 ## string_flag
 
@@ -38,7 +38,7 @@ A string flag.
 | <a id="string_flag-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
-<a id="#exercise_the_api"></a>
+<a id="exercise_the_api"></a>
 
 ## exercise_the_api
 
@@ -50,7 +50,7 @@ exercise_the_api()
 
 
 
-<a id="#transition_func"></a>
+<a id="transition_func"></a>
 
 ## transition_func
 

--- a/test/testdata/cpp_basic_test/golden.md
+++ b/test/testdata/cpp_basic_test/golden.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#cpp_related_rule"></a>
+<a id="cpp_related_rule"></a>
 
 ## cpp_related_rule
 

--- a/test/testdata/filter_rules_test/golden.md
+++ b/test/testdata/filter_rules_test/golden.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#my_rule"></a>
+<a id="my_rule"></a>
 
 ## my_rule
 
@@ -22,7 +22,7 @@ This is my rule. It does stuff.
 | <a id="my_rule-second"></a>second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 
 
-<a id="#whitelisted_dep_rule"></a>
+<a id="whitelisted_dep_rule"></a>
 
 ## whitelisted_dep_rule
 

--- a/test/testdata/function_basic_test/golden.md
+++ b/test/testdata/function_basic_test/golden.md
@@ -2,7 +2,7 @@
 
 A test that verifies basic user function documentation.
 
-<a id="#check_sources"></a>
+<a id="check_sources"></a>
 
 ## check_sources
 
@@ -32,7 +32,7 @@ Use `bazel build` to run the check.
 | <a id="check_sources-struct_param"></a>struct_param |  <p align="center"> - </p>   |  <code>struct(foo = "bar")</code> |
 
 
-<a id="#deprecated_do_not_use"></a>
+<a id="deprecated_do_not_use"></a>
 
 ## deprecated_do_not_use
 
@@ -48,7 +48,7 @@ This function is deprecated.
 Use literally anything but this function.
 
 
-<a id="#returns_a_thing"></a>
+<a id="returns_a_thing"></a>
 
 ## returns_a_thing
 
@@ -70,7 +70,7 @@ Returns a suffixed name.
 A suffixed version of the name.
 
 
-<a id="#undocumented_function"></a>
+<a id="undocumented_function"></a>
 
 ## undocumented_function
 

--- a/test/testdata/generated_bzl_test/golden.md
+++ b/test/testdata/generated_bzl_test/golden.md
@@ -2,7 +2,7 @@
 
 A direct dependency file of the input file.
 
-<a id="#my_rule"></a>
+<a id="my_rule"></a>
 
 ## my_rule
 

--- a/test/testdata/html_tables_template_test/golden.md
+++ b/test/testdata/html_tables_template_test/golden.md
@@ -2,7 +2,7 @@
 
 Input file for markdown template test
 
-<a id="#example_rule"></a>
+<a id="example_rule"></a>
 
 ## example_rule
 
@@ -58,7 +58,7 @@ String; optional
 </table>
 
 
-<a id="#ExampleProviderInfo"></a>
+<a id="ExampleProviderInfo"></a>
 
 ## ExampleProviderInfo
 
@@ -110,7 +110,7 @@ A string representing baz
 </table>
 
 
-<a id="#example_function"></a>
+<a id="example_function"></a>
 
 ## example_function
 
@@ -159,7 +159,7 @@ This parameter does bar related things.
 </table>
 
 
-<a id="#example_aspect"></a>
+<a id="example_aspect"></a>
 
 ## example_aspect
 

--- a/test/testdata/java_basic_test/golden.md
+++ b/test/testdata/java_basic_test/golden.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#java_related_rule"></a>
+<a id="java_related_rule"></a>
 
 ## java_related_rule
 

--- a/test/testdata/local_repository_test/golden.md
+++ b/test/testdata/local_repository_test/golden.md
@@ -2,7 +2,7 @@
 
 A test that verifies documenting functions in an input file under a local_repository.
 
-<a id="#min"></a>
+<a id="min"></a>
 
 ## min
 

--- a/test/testdata/macro_kwargs_test/golden.md
+++ b/test/testdata/macro_kwargs_test/golden.md
@@ -2,7 +2,7 @@
 
 Tests for functions which use *args or **kwargs
 
-<a id="#macro_with_args"></a>
+<a id="macro_with_args"></a>
 
 ## macro_with_args
 
@@ -25,7 +25,7 @@ My args macro is OK.
 An empty list.
 
 
-<a id="#macro_with_both"></a>
+<a id="macro_with_both"></a>
 
 ## macro_with_both
 
@@ -53,7 +53,7 @@ Not much else to say.
 An empty list.
 
 
-<a id="#macro_with_kwargs"></a>
+<a id="macro_with_kwargs"></a>
 
 ## macro_with_kwargs
 

--- a/test/testdata/misc_apis_test/golden.md
+++ b/test/testdata/misc_apis_test/golden.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#my_rule"></a>
+<a id="my_rule"></a>
 
 ## my_rule
 
@@ -25,7 +25,7 @@ This rule exercises some of the build API.
 | <a id="my_rule-tool"></a>tool |  The location of the tool to use.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //foo/bar/baz:target |
 
 
-<a id="#MyInfo"></a>
+<a id="MyInfo"></a>
 
 ## MyInfo
 
@@ -44,7 +44,7 @@ MyInfo(<a href="#MyInfo-foo">foo</a>, <a href="#MyInfo-bar">bar</a>)
 | <a id="MyInfo-bar"></a>bar |  Something bar-related.    |
 
 
-<a id="#exercise_the_api"></a>
+<a id="exercise_the_api"></a>
 
 ## exercise_the_api
 
@@ -56,7 +56,7 @@ exercise_the_api()
 
 
 
-<a id="#my_rule_impl"></a>
+<a id="my_rule_impl"></a>
 
 ## my_rule_impl
 

--- a/test/testdata/multi_level_namespace_test/golden.md
+++ b/test/testdata/multi_level_namespace_test/golden.md
@@ -2,7 +2,7 @@
 
 A test that verifies documenting a multi-leveled namespace of functions.
 
-<a id="#my_namespace.min"></a>
+<a id="my_namespace.min"></a>
 
 ## my_namespace.min
 
@@ -24,7 +24,7 @@ Returns the minimum of given elements.
 The minimum integer in the given list.
 
 
-<a id="#my_namespace.math.min"></a>
+<a id="my_namespace.math.min"></a>
 
 ## my_namespace.math.min
 
@@ -46,7 +46,7 @@ Returns the minimum of given elements.
 The minimum integer in the given list.
 
 
-<a id="#my_namespace.foo.bar.baz"></a>
+<a id="my_namespace.foo.bar.baz"></a>
 
 ## my_namespace.foo.bar.baz
 
@@ -58,7 +58,7 @@ This function does nothing.
 
 
 
-<a id="#my_namespace.one.two.min"></a>
+<a id="my_namespace.one.two.min"></a>
 
 ## my_namespace.one.two.min
 
@@ -80,7 +80,7 @@ Returns the minimum of given elements.
 The minimum integer in the given list.
 
 
-<a id="#my_namespace.one.three.does_nothing"></a>
+<a id="my_namespace.one.three.does_nothing"></a>
 
 ## my_namespace.one.three.does_nothing
 

--- a/test/testdata/multi_level_namespace_test_with_whitelist/golden.md
+++ b/test/testdata/multi_level_namespace_test_with_whitelist/golden.md
@@ -4,7 +4,7 @@ A test that verifies documenting a multi-leveled namespace of functions with whi
 The whitelist symbols should cause everything in my_namespace to to be documented, but only a
 specific symbol in other_namespace to be documented.
 
-<a id="#my_namespace.min"></a>
+<a id="my_namespace.min"></a>
 
 ## my_namespace.min
 
@@ -22,7 +22,7 @@ Returns the minimum of given elements.
 | <a id="my_namespace.min-integers"></a>integers |  <p align="center"> - </p>   |  none |
 
 
-<a id="#my_namespace.math.min"></a>
+<a id="my_namespace.math.min"></a>
 
 ## my_namespace.math.min
 
@@ -40,7 +40,7 @@ Returns the minimum of given elements.
 | <a id="my_namespace.math.min-integers"></a>integers |  <p align="center"> - </p>   |  none |
 
 
-<a id="#other_namespace.foo.nothing"></a>
+<a id="other_namespace.foo.nothing"></a>
 
 ## other_namespace.foo.nothing
 

--- a/test/testdata/multiple_files_test/golden.md
+++ b/test/testdata/multiple_files_test/golden.md
@@ -2,7 +2,7 @@
 
 A direct dependency file of the input file.
 
-<a id="#my_rule"></a>
+<a id="my_rule"></a>
 
 ## my_rule
 
@@ -22,7 +22,7 @@ This is my rule. It does stuff.
 | <a id="my_rule-second"></a>second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 
 
-<a id="#other_rule"></a>
+<a id="other_rule"></a>
 
 ## other_rule
 
@@ -42,7 +42,7 @@ This is another rule.
 | <a id="other_rule-third"></a>third |  third other_rule doc string   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
-<a id="#yet_another_rule"></a>
+<a id="yet_another_rule"></a>
 
 ## yet_another_rule
 
@@ -61,7 +61,7 @@ This is yet another rule
 | <a id="yet_another_rule-fifth"></a>fifth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
-<a id="#top_fun"></a>
+<a id="top_fun"></a>
 
 ## top_fun
 

--- a/test/testdata/multiple_rules_test/golden.md
+++ b/test/testdata/multiple_rules_test/golden.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#my_rule"></a>
+<a id="my_rule"></a>
 
 ## my_rule
 
@@ -22,7 +22,7 @@ This is my rule. It does stuff.
 | <a id="my_rule-second"></a>second |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 
 
-<a id="#other_rule"></a>
+<a id="other_rule"></a>
 
 ## other_rule
 
@@ -42,7 +42,7 @@ This is another rule.
 | <a id="other_rule-third"></a>third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
-<a id="#yet_another_rule"></a>
+<a id="yet_another_rule"></a>
 
 ## yet_another_rule
 
@@ -61,7 +61,7 @@ This is yet another rule
 | <a id="yet_another_rule-fifth"></a>fifth |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
-<a id="#my_rule_impl"></a>
+<a id="my_rule_impl"></a>
 
 ## my_rule_impl
 

--- a/test/testdata/namespace_test/golden.md
+++ b/test/testdata/namespace_test/golden.md
@@ -2,7 +2,7 @@
 
 A test that verifies documenting a namespace of functions.
 
-<a id="#my_namespace.assert_non_empty"></a>
+<a id="my_namespace.assert_non_empty"></a>
 
 ## my_namespace.assert_non_empty
 
@@ -21,7 +21,7 @@ Asserts the two given lists are not empty.
 | <a id="my_namespace.assert_non_empty-other_list"></a>other_list |  The second list   |  none |
 
 
-<a id="#my_namespace.min"></a>
+<a id="my_namespace.min"></a>
 
 ## my_namespace.min
 
@@ -43,7 +43,7 @@ Returns the minimum of given elements.
 The minimum integer in the given list.
 
 
-<a id="#my_namespace.join_strings"></a>
+<a id="my_namespace.join_strings"></a>
 
 ## my_namespace.join_strings
 

--- a/test/testdata/provider_basic_test/golden.md
+++ b/test/testdata/provider_basic_test/golden.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#MyFooInfo"></a>
+<a id="MyFooInfo"></a>
 
 ## MyFooInfo
 
@@ -21,7 +21,7 @@ Stores information about a foo.
 | <a id="MyFooInfo-baz"></a>baz |  (Undocumented)    |
 
 
-<a id="#MyPoorlyDocumentedInfo"></a>
+<a id="MyPoorlyDocumentedInfo"></a>
 
 ## MyPoorlyDocumentedInfo
 
@@ -35,7 +35,7 @@ MyPoorlyDocumentedInfo()
 
 
 
-<a id="#MyVeryDocumentedInfo"></a>
+<a id="MyVeryDocumentedInfo"></a>
 
 ## MyVeryDocumentedInfo
 

--- a/test/testdata/providers_for_attributes_test/golden.md
+++ b/test/testdata/providers_for_attributes_test/golden.md
@@ -2,7 +2,7 @@
 
 The input file for the providers for attributes test
 
-<a id="#my_rule"></a>
+<a id="my_rule"></a>
 
 ## my_rule
 
@@ -26,7 +26,7 @@ This rule does things.
 | <a id="my_rule-third"></a>third |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
-<a id="#MyProviderInfo"></a>
+<a id="MyProviderInfo"></a>
 
 ## MyProviderInfo
 
@@ -45,7 +45,7 @@ MyProviderInfo(<a href="#MyProviderInfo-foo">foo</a>, <a href="#MyProviderInfo-b
 | <a id="MyProviderInfo-bar"></a>bar |  Something bar-related.    |
 
 
-<a id="#OtherProviderInfo"></a>
+<a id="OtherProviderInfo"></a>
 
 ## OtherProviderInfo
 
@@ -59,7 +59,7 @@ OtherProviderInfo()
 
 
 
-<a id="#my_rule_impl"></a>
+<a id="my_rule_impl"></a>
 
 ## my_rule_impl
 

--- a/test/testdata/py_rule_test/golden.md
+++ b/test/testdata/py_rule_test/golden.md
@@ -2,7 +2,7 @@
 
 The input file for the python rule test
 
-<a id="#py_related_rule"></a>
+<a id="py_related_rule"></a>
 
 ## py_related_rule
 

--- a/test/testdata/repo_rules_test/golden.md
+++ b/test/testdata/repo_rules_test/golden.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#my_repo"></a>
+<a id="my_repo"></a>
 
 ## my_repo
 

--- a/test/testdata/same_level_file_test/golden.md
+++ b/test/testdata/same_level_file_test/golden.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#my_rule"></a>
+<a id="my_rule"></a>
 
 ## my_rule
 

--- a/test/testdata/simple_test/golden.md
+++ b/test/testdata/simple_test/golden.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#my_rule"></a>
+<a id="my_rule"></a>
 
 ## my_rule
 

--- a/test/testdata/struct_default_value_test/golden.md
+++ b/test/testdata/struct_default_value_test/golden.md
@@ -2,7 +2,7 @@
 
 The input file for struct default values test
 
-<a id="#check_struct_default_values"></a>
+<a id="check_struct_default_values"></a>
 
 ## check_struct_default_values
 

--- a/test/testdata/unknown_name_test/golden.md
+++ b/test/testdata/unknown_name_test/golden.md
@@ -2,7 +2,7 @@
 
 
 
-<a id="#my_rule_impl"></a>
+<a id="my_rule_impl"></a>
 
 ## my_rule_impl
 


### PR DESCRIPTION
The URL fragment `something.html#xyz` links to an element with `id=xyz`,
not `id="#xyz"` like was being generated. In most cases, this didn't
matter, because `some_thing` generates a heading with `id=some_thing` in
addition to the `<a>` which didn't work. However, `SomeThing` produces a
heading with `id=something`, which doesn't match, so clicking the
relevant links does not scroll the page to the intended location.

If anybody was linking to `something.html##xyz`, those won't go to the
intended location any more, but that doesn't seem like intended behavior
to me.