### PR TITLE
update rules_proto

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,11 +71,10 @@ rules_pkg_dependencies()
 # Needed as a transitive dependency of @io_bazel
 http_archive(
     name = "rules_proto",
-    sha256 = "88b0a90433866b44bb4450d4c30bc5738b8c4f9c9ba14e9661deb123f56a833d",
-    strip_prefix = "rules_proto-b0cc14be5da05168b01db282fe93bdf17aa2b9f4",
+    sha256 = "9850fcf6ad40fa348e6f13b2cfef4bb4639762f804794f2bf61d988f4ba0dae9",
+    strip_prefix = "rules_proto-4.0.0-3.19.2-2",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/b0cc14be5da05168b01db282fe93bdf17aa2b9f4.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/b0cc14be5da05168b01db282fe93bdf17aa2b9f4.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0-3.19.2-2.tar.gz",
     ],
 )
 


### PR DESCRIPTION
To include https://github.com/bazelbuild/rules_proto/pull/117, without which builds fail due to a missing zlib version.