### PR TITLE
Prepare release 0.5.1 to fix missing zlib build failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Release 0.5.1
+
+Bugfix release: minor fixes, including a fix for build failure due to missing zlib version.
+
+**Contributors**
+
+aiuto, Alexandre Rostovtsev, Brian Silverman, Casey, Xùdōng Yáng
+
 ## Release 0.5.0
 
 This release includes many fixes for Stardoc's markdown output, plus:

--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of Stardoc."""
 
-version = "0.5.0"
+version = "0.5.1"


### PR DESCRIPTION
We need a release containing the fix in https://github.com/bazelbuild/stardoc/pull/125