### PR TITLE
Use specific versioned tarballs of dependencies instead of git checkouts

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,7 +16,7 @@ git_repository(
     name = "io_bazel",
     commit = "4e551f5a0c4caae251648104df40ccbb59951264",  # Feb 09, 2022
     remote = "https://github.com/bazelbuild/bazel.git",
-    shallow_since = "1644438074 -0800",
+    shallow_since = "1644438166 -0800",
 )
 
 # The following binds are needed for building protobuf java libraries.

--- a/setup.bzl
+++ b/setup.bzl
@@ -25,17 +25,18 @@ def stardoc_repositories():
     _include_if_not_defined(
         http_archive,
         name = "bazel_skylib",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/16de038c484145363340eeaf0e97a0c9889a931b.tar.gz"],  # 2020-08-11
-        sha256 = "96e0cd3f731f0caef9e9919aa119ecc6dace36b149c2f47e40aa50587790402b",
-        strip_prefix = "bazel-skylib-16de038c484145363340eeaf0e97a0c9889a931b",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+        ],
+        sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
     )
     _include_if_not_defined(
         http_archive,
         name = "rules_java",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
-            "https://github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_java/releases/download/4.0.0/rules_java-4.0.0.tar.gz",
+            "https://github.com/bazelbuild/rules_java/releases/download/4.0.0/rules_java-4.0.0.tar.gz",
         ],
-        sha256 = "bc81f1ba47ef5cc68ad32225c3d0e70b8c6f6077663835438da8d5733f917598",
-        strip_prefix = "rules_java-7cf3cefd652008d0a64a419c34c13bdca6c8f178",
+        sha256 = "34b41ec683e67253043ab1a3d1e8b7c61e4e8edefbcad485381328c934d072fe",
     )


### PR DESCRIPTION
For smaller download sizes and general user friendliness.

Note that we are for now using rules_java 4.0.0 instead of 5.0.0 due to https://github.com/bazelbuild/rules_java/issues/52