### PR TITLE
Switch from cfg = "host" to cfg = "exec" to fix buildifier failures

### DIFF
--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -158,14 +158,14 @@ For example, if `//foo:bar.bzl` does not build except when a user would specify
             doc = "The location of the stardoc tool.",
             allow_files = True,
             default = Label("//stardoc:stardoc"),
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
         "renderer": attr.label(
             doc = "The location of the renderer tool.",
             allow_files = True,
             default = Label("//stardoc:renderer"),
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
         "aspect_template": attr.label(

--- a/test/testdata/misc_apis_test/input.bzl
+++ b/test/testdata/misc_apis_test/input.bzl
@@ -49,7 +49,7 @@ A list of dependencies.
             doc = "The location of the tool to use.",
             allow_files = True,
             default = Label("//foo/bar/baz:target"),
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
         "out": attr.output(


### PR DESCRIPTION
See https://buildkite.com/bazel/stardoc/builds/454