### PR TITLE
Prepare release 0.5.2 to fix crash on config_common.toolchain_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Release 0.5.2
+
+Bugfix release: fixes crash with `config_common.toolchain_type`.
+
+**Contributors**
+
+Alexandre Rostovtsev, Keith Smiley
+
 ## Release 0.5.1
 
 Bugfix release: minor fixes, including a fix for build failure due to missing zlib version.

--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of Stardoc."""
 
-version = "0.5.1"
+version = "0.5.2"


### PR DESCRIPTION
See #130.