### PR TITLE
Fix 'extensions' link in getting_started_stardoc.md

### DIFF
--- a/docs/getting_started_stardoc.md
+++ b/docs/getting_started_stardoc.md
@@ -8,7 +8,7 @@ Starlark generates one documentation page per `stardoc` target.
 
 If you are new to writing build rules for Bazel, please read the Bazel
 documentation on [writing
-extensions](https://www.bazel.build/docs/skylark/concepts.html)
+extensions](https://bazel.build/extending/concepts)
 
 ## Setup
 


### PR DESCRIPTION
The doc in `docs/getting_started_stardoc.md` contained a link 'writing
extensions' that pointed to https://www.bazel.build/docs/skylark/concepts.html
This page returns a 404. I have updated the link to point to
https://bazel.build/extending/concepts , which seems to have the same contents
as the previous page as verified by a search on http://web.archive.org/