### PR TITLE
Add more situations to the angle bracket test.

### DIFF
--- a/test/testdata/angle_bracket_test/golden.md
+++ b/test/testdata/angle_bracket_test/golden.md
@@ -2,15 +2,21 @@
 
 Input file to test &lt;angle bracket bugs&gt;
 
-See https://github.com/bazelbuild/skydoc/issues/186
-and https://github.com/bazelbuild/stardoc/issues/132
+See https://github.com/bazelbuild/skydoc/issues/186,
+https://github.com/bazelbuild/stardoc/issues/132,
+and https://github.com/bazelbuild/stardoc/issues/137.
+
+&lt;Angle brackets&gt; need to be escaped in some contexts.
+They also need to _not_ be escaped when they're enclosed
+in a `<code block>`.
+
 
 <a id="my_anglebrac"></a>
 
 ## my_anglebrac
 
 <pre>
-my_anglebrac(<a href="#my_anglebrac-name">name</a>, <a href="#my_anglebrac-useless">useless</a>)
+my_anglebrac(<a href="#my_anglebrac-name">name</a>, <a href="#my_anglebrac-also_useless">also_useless</a>, <a href="#my_anglebrac-useless">useless</a>)
 </pre>
 
 Rule with &lt;brackets&gt;
@@ -21,6 +27,7 @@ Rule with &lt;brackets&gt;
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="my_anglebrac-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="my_anglebrac-also_useless"></a>also_useless |  Args with some formatted tags: <code>&lt;tag&gt;</code>   | String | optional | <code>"1&lt;&lt;5"</code> |
 | <a id="my_anglebrac-useless"></a>useless |  Args with some tags: &lt;tag1&gt;, &lt;tag2&gt;   | String | optional | <code>"Find &lt;brackets&gt;"</code> |
 
 
@@ -49,12 +56,19 @@ Information with &lt;brackets&gt;
 ## bracket_function
 
 <pre>
-bracket_function(<a href="#bracket_function-param">param</a>)
+bracket_function(<a href="#bracket_function-param">param</a>, <a href="#bracket_function-md_string">md_string</a>)
 </pre>
 
 Dummy docstring with &lt;brackets&gt;.
 
 This rule runs checks on &lt;angle brackets&gt;.
+
+Sometimes, we have such things on their own, but they may
+also appear in code blocks, like
+
+```starlark
+foo = "<thing>"
+```
 
 
 **PARAMETERS**
@@ -63,6 +77,7 @@ This rule runs checks on &lt;angle brackets&gt;.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="bracket_function-param"></a>param |  an arg with **formatted** docstring, &lt;default&gt; by default.   |  <code>"&lt;default&gt;"</code> |
+| <a id="bracket_function-md_string"></a>md_string |  A markdown string.   |  <code>"&#96;1&lt;&lt;10&#96;"</code> |
 
 **RETURNS**
 
@@ -70,7 +85,7 @@ some &lt;angled&gt; brackets
 
 **DEPRECATED**
 
-deprecated for &lt;reasons&gt;
+deprecated for &lt;reasons&gt; as well as `<reasons>`.
 
 
 <a id="bracket_aspect"></a>
@@ -81,7 +96,14 @@ deprecated for &lt;reasons&gt;
 bracket_aspect(<a href="#bracket_aspect-name">name</a>, <a href="#bracket_aspect-brackets">brackets</a>)
 </pre>
 
-Aspect with &lt;brackets&gt;
+Aspect.
+
+Sometimes, we want a code block like
+```starlark
+foo = "<brackets>"
+```
+which includes angle brackets.
+
 
 **ASPECT ATTRIBUTES**
 

--- a/test/testdata/angle_bracket_test/input.bzl
+++ b/test/testdata/angle_bracket_test/input.bzl
@@ -1,23 +1,37 @@
 """Input file to test <angle bracket bugs>
 
-See https://github.com/bazelbuild/skydoc/issues/186
-and https://github.com/bazelbuild/stardoc/issues/132"""
+See https://github.com/bazelbuild/skydoc/issues/186,
+https://github.com/bazelbuild/stardoc/issues/132,
+and https://github.com/bazelbuild/stardoc/issues/137.
 
-def bracket_function(param = "<default>"):
+<Angle brackets> need to be escaped in some contexts.
+They also need to _not_ be escaped when they're enclosed
+in a `<code block>`.
+"""
+
+def bracket_function(param = "<default>", md_string = "`1<<10`"):
     """Dummy docstring with <brackets>.
 
     This rule runs checks on <angle brackets>.
 
+    Sometimes, we have such things on their own, but they may
+    also appear in code blocks, like
+
+    ```starlark
+    foo = "<thing>"
+    ```
+
     Args:
         param: an arg with **formatted** docstring, <default> by default.
+        md_string: A markdown string.
 
     Returns:
         some <angled> brackets
 
     Deprecated:
-        deprecated for <reasons>
+        deprecated for <reasons> as well as `<reasons>`.
     """
-    return param
+    return param or md_string
 
 # buildifier: disable=unsorted-dict-items
 bracketuse = provider(
@@ -41,6 +55,10 @@ my_anglebrac = rule(
             doc = "Args with some tags: <tag1>, <tag2>",
             default = "Find <brackets>",
         ),
+        "also_useless": attr.string(
+            doc = "Args with some formatted tags: `<tag>`",
+            default = "1<<5",
+        ),
     },
 )
 
@@ -50,7 +68,14 @@ def _bracket_aspect_impl(ctx):
 
 bracket_aspect = aspect(
     implementation = _bracket_aspect_impl,
-    doc = "Aspect with <brackets>",
+    doc = """Aspect.
+
+Sometimes, we want a code block like
+```starlark
+foo = "<brackets>"
+```
+which includes angle brackets.
+""",
     attr_aspects = ["deps"],
     attrs = {
         "brackets": attr.string(


### PR DESCRIPTION
Examples to demonstrate
https://github.com/bazelbuild/stardoc/issues/137.

Currently these tests will fail.  I actually don't know where to find the code behind `util.htmlEscape`, which is what would need to be fixed.