### PR TITLE
Update rules_pkg to 0.8

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,10 +57,10 @@ git_repository(
 # Needed for //distro:__pkg__ and as a transitive dependency of @io_bazel
 http_archive(
     name = "rules_pkg",
-    sha256 = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
+    sha256 = "eea0f59c28a9241156a47d7a8e32db9122f3d50b505fae0f33de6ce4d9b61834",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
-        "https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Resolves config_setting visibility failures from https://github.com/bazelbuild/bazel/issues/12933:

    ERROR: /var/lib/buildkite-agent/builds/bk-docker-zr2k/bazel-downstream-projects/stardoc/distro/BUILD:33:8: in
    pkg_tar_impl rule //distro:distro_bins: target '@rules_pkg//pkg/private:private_stamp_detect' is not visible from
    target '//distro:distro_bins'. Check the visibility declaration of the former target if you think the dependency is
    legitimate

See https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1320#018435e1-7429-4329-808a-731599f24623.