### PR TITLE
Use backtick not `<code>` for attr default values

### DIFF
--- a/stardoc/templates/markdown_tables/func.vm
+++ b/stardoc/templates/markdown_tables/func.vm
@@ -15,7 +15,7 @@ ${util.htmlEscape($funcInfo.docString)}
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 #foreach ($param in $funcInfo.getParameterList())
-| <a id="${funcInfo.functionName}-${param.name}"></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end  | #if(!$param.getDefaultValue().isEmpty()) <code>${util.htmlEscape($param.getDefaultValue())}</code> #else none #end|
+| <a id="${funcInfo.functionName}-${param.name}"></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end  | #if(!$param.getDefaultValue().isEmpty()) `${util.htmlEscape($param.getDefaultValue())}` #else none #end|
 #end
 #end
 #if (!$funcInfo.getReturn().docString.isEmpty())


### PR DESCRIPTION
GitHub Pages doesn't recognise `<code>` blocks, so renders these attributes with smart-quotes, which means you can't copy-paste them into a starlark file.

Fixes #142