### PR TITLE
Add bazel patch to work around underdefined dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,6 +15,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "io_bazel",
     commit = "901c75e459d737220cb8e29649c1b6ba24e2221d",  # Sep 27, 2022
+    patches = ["@//:bazel.patch"],  # TODO: Remove after next bazel update
     remote = "https://github.com/bazelbuild/bazel.git",
     shallow_since = "1664304093 -0700",
 )

--- a/bazel.patch
+++ b/bazel.patch
@@ -1,0 +1,14 @@
+--- src/main/native/BUILD
++++ src/main/native/BUILD
+@@ -71,7 +71,10 @@ cc_binary(
+     ],
+     includes = ["."],  # For jni headers.
+     linkopts = select({
+-        "//src/conditions:darwin": ["-framework CoreServices"],
++        "//src/conditions:darwin": [
++            "-Wl,-framework,CoreServices",
++            "-Wl,-framework,IOKit",
++        ],
+         "//conditions:default": [],
+     }),
+     linkshared = 1,


### PR DESCRIPTION
Fixes https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2824#0185bd7e-6fed-4c16-ad52-256b600d4ae3 for now. Updating bazel requires more work because of third party dependencies:

```
ERROR: /private/var/tmp/_bazel_ksmiley/430ca27aaa11819957cd32dd0f9637d8/external/io_bazel/third_party/BUILD:464:13: no such package '@maven//': The repository '@maven' could not be resolved: Repository '@maven' is not defined and referenced by '@io_bazel//third_party:guava'
```