### PR TITLE
Add a proto_library target for stardoc_output.proto.

### DIFF
--- a/stardoc/proto/BUILD
+++ b/stardoc/proto/BUILD
@@ -2,6 +2,11 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
+proto_library(
+    name = "stardoc_output_proto",
+    srcs = ["stardoc_output.proto"],
+)
+
 exports_files(["stardoc_output.proto"])
 
 # Sources needed for release tarball.


### PR DESCRIPTION
This makes it possible to use the protocol buffer definitions in Bazel-built binaries generating or consuming output messages.