### PR TITLE
Add missing license blurb

### DIFF
--- a/test/bzlmod/def.bzl
+++ b/test/bzlmod/def.bzl
@@ -1,3 +1,17 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """A simple macro used to test stardoc."""
 
 load("@my_skylib//rules:write_file.bzl", "write_file")


### PR DESCRIPTION
Our internal system complains about the lack of license header in a .bzl file.