### PR TITLE
Prepare release 0.5.5 with java toolchains breakage fix for Bazel at HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release 0.5.5
 
-Bugfix release: update '@rules_java` dependency to fix breakage with Bazel at HEAD.
+Bugfix release: update `@rules_java` dependency to fix breakage with Bazel at HEAD.
 
 **Contributors**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Release 0.5.5
+
+Bugfix release: update '@rules_java` dependency to fix breakage with Bazel at HEAD.
+
+**Contributors**
+
+Alexandre Rostovtsev
+
+
 ## Release 0.5.4
 
 **New Features**

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "stardoc",
-    version = "0.5.4",
+    version = "0.5.5",
     compatibility_level = 1,
 )
 

--- a/setup.bzl
+++ b/setup.bzl
@@ -35,10 +35,10 @@ def stardoc_repositories():
         http_archive,
         name = "rules_java",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_java/releases/download/5.3.5/rules_java-5.3.5.tar.gz",
-            "https://github.com/bazelbuild/rules_java/releases/download/5.3.5/rules_java-5.3.5.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_java/releases/download/6.0.0/rules_java-6.0.0.tar.gz",
+            "https://github.com/bazelbuild/rules_java/releases/download/6.0.0/rules_java-6.0.0.tar.gz",
         ],
-        sha256 = "c73336802d0b4882e40770666ad055212df4ea62cfa6edf9cb0f9d29828a0934",
+        sha256 = "469b7f3b580b4fcf8112f4d6d0d5a4ce8e1ad5e21fee67d8e8335d5f8b3debab",
     )
     _include_if_not_defined(
         http_archive,

--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of Stardoc."""
 
-version = "0.5.4"
+version = "0.5.5"


### PR DESCRIPTION
Update rules_java dep to fix "No matching toolchains" errors with Bazel at HEAD, i.e. after https://github.com/bazelbuild/bazel/commit/975866a3e09212766bd353a90a8c42efe91d53ab

This error warrants an immediate release because it affects users of Stardoc releases, not just Stardoc itself.

See https://buildkite.com/bazel/bazel-skylib/builds/2692#0188728a-5bf4-4bb0-8d3a-6bc726a54f26 for an example failure.