### PR TITLE
Prepare release 0.5.6, now with java toolchains breakage fix with bzlmod too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Release 0.5.5
+## Release 0.5.6 (initially tagged as 0.5.5)
 
 Bugfix release: update `@rules_java` dependency to fix breakage with Bazel at HEAD.
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,9 +1,9 @@
 module(
     name = "stardoc",
-    version = "0.5.5",
+    version = "0.5.6",
     compatibility_level = 1,
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.2.1")
-bazel_dep(name = "rules_java", version = "5.3.5")
+bazel_dep(name = "rules_java", version = "6.0.0")
 bazel_dep(name = "rules_license", version = "0.0.3")

--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of Stardoc."""
 
-version = "0.5.5"
+version = "0.5.6"


### PR DESCRIPTION
I forgot to bump the rules_java dep in MODULE.bazel.

We ought to have a consistency check for this...