### PR TITLE
Add tableOfContents to stardoc

### DIFF
--- a/src/main/java/com/google/devtools/build/skydoc/rendering/MarkdownRenderer.java
+++ b/src/main/java/com/google/devtools/build/skydoc/rendering/MarkdownRenderer.java
@@ -61,9 +61,36 @@ public class MarkdownRenderer {
    * summary for the input Starlark module.
    */
   public String renderMarkdownHeader(ModuleInfo moduleInfo) throws IOException {
+    StringBuilder builder = new StringBuilder();
+    if (moduleInfo.getRuleInfoCount() > 0) {
+      builder.append("## Rules:\n");
+      for (RuleInfo info : moduleInfo.getRuleInfoList()) {
+        builder.append(String.format("* [%s](#%<s)\n", info.getRuleName()));
+      }
+    }
+    if (moduleInfo.getProviderInfoCount() > 0) {
+      builder.append("## Providers:\n");
+      for (ProviderInfo info : moduleInfo.getProviderInfoList()) {
+        builder.append(String.format("* [%s](#%<s)\n", info.getProviderName()));
+      }
+    }
+    if (moduleInfo.getFuncInfoCount() > 0) {
+      builder.append("## Functions:\n");
+      for (StarlarkFunctionInfo info : moduleInfo.getFuncInfoList()) {
+        builder.append(String.format("* [%s](#%<s)\n", info.getFunctionName()));
+      }
+    }
+    if (moduleInfo.getAspectInfoCount() > 0) {
+      builder.append("## Aspects:\n");
+      for (AspectInfo info : moduleInfo.getAspectInfoList()) {
+        builder.append(String.format("* [%s](#%<s)\n", info.getAspectName()));
+      }
+    }
+
     ImmutableMap<String, Object> vars =
         ImmutableMap.of(
-            "util", new MarkdownUtil(), "moduleDocstring", moduleInfo.getModuleDocstring());
+            "util", new MarkdownUtil(), "moduleDocstring", moduleInfo.getModuleDocstring(),
+            "tableOfContents", builder.toString());
     Reader reader = readerFromPath(headerTemplateFilename);
     try {
       return Template.parseFrom(reader).evaluate(vars);

--- a/test/testdata/input_template_test/golden.md
+++ b/test/testdata/input_template_test/golden.md
@@ -2,6 +2,17 @@
 
 Module Docstring: "Input file for input template test"
 
+Table Of Contents: "## Rules:
+* [my_example](#my_example)
+## Providers:
+* [example](#example)
+## Functions:
+* [my_aspect_impl](#my_aspect_impl)
+* [template_function](#template_function)
+## Aspects:
+* [my_aspect](#my_aspect)
+"
+
 <a id="#my_example"></a>
 
 ## my_example

--- a/test/testdata/input_template_test/header.vm
+++ b/test/testdata/input_template_test/header.vm
@@ -1,3 +1,5 @@
 <!-- THIS HEADER IS FOR input_template_test ONLY -->
 
 Module Docstring: "${moduleDocstring}"
+
+Table Of Contents: "${tableOfContents}"


### PR DESCRIPTION
This adds a new replacement in stardoc headers for a simple table of contents that prints each different type of documented symbol, and a link to each one that will be on the page. This is much easier than having consumers enumerate all the symbols in a file to build this up themselves.

https://github.com/bazelbuild/bazel/pull/15389