### PR TITLE
Prepare release 0.6.2

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -19,12 +19,10 @@ tasks:
   build_and_test_windows:
     name: Build and test - Windows
     platform: windows
-    environment:
-      # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
-      # when using --incompatible_disable_starlark_host_transitions on Windows
-      BAZELISK_SHUTDOWN: "1"
     build_flags:
       - "--incompatible_disable_starlark_host_transitions"
+      # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
+      - "--noexperimental_repository_cache_hardlinks"
     build_targets:
       - "//..."
     test_targets:
@@ -45,12 +43,10 @@ tasks:
     name: Build and test - Bazel last green - Windows
     platform: windows
     bazel: last_green
-    environment:
-      # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
-      # when using --incompatible_disable_starlark_host_transitions on Windows
-      BAZELISK_SHUTDOWN: "1"
     build_flags:
       - "--incompatible_disable_starlark_host_transitions"
+      # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
+      - "--noexperimental_repository_cache_hardlinks"
     build_targets:
       - "//..."
     test_targets:
@@ -72,10 +68,6 @@ tasks:
     name: Bzlmod example - Windows
     platform: windows
     working_directory: test/bzlmod
-    environment:
-      # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
-      # when using --incompatible_disable_starlark_host_transitions on Windows
-      BAZELISK_SHUTDOWN: "1"
     build_flags:
       - "--incompatible_disable_starlark_host_transitions"
       - "--enable_bzlmod"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,6 +4,7 @@ matrix:
     - ubuntu1804
     - ubuntu2004
     - macos
+    - windows
 
 tasks:
   build_and_test:
@@ -13,20 +14,8 @@ tasks:
       - "--incompatible_disable_starlark_host_transitions"
     build_targets:
       - "//..."
-    test_targets:
-      - "//..."
-
-  build_and_test_windows:
-    name: Build and test - Windows
-    platform: windows
-    environment:
-      # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
-      # when using --incompatible_disable_starlark_host_transitions on Windows
-      BAZELISK_SHUTDOWN: "1"
-    build_flags:
+    test_flags:
       - "--incompatible_disable_starlark_host_transitions"
-    build_targets:
-      - "//..."
     test_targets:
       - "//..."
 
@@ -38,21 +27,8 @@ tasks:
       - "--incompatible_disable_starlark_host_transitions"
     build_targets:
       - "//..."
-    test_targets:
-      - "//..."
-
-  build_and_test_last_green_windows:
-    name: Build and test - Bazel last green - Windows
-    platform: windows
-    bazel: last_green
-    environment:
-      # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
-      # when using --incompatible_disable_starlark_host_transitions on Windows
-      BAZELISK_SHUTDOWN: "1"
-    build_flags:
+    test_flags:
       - "--incompatible_disable_starlark_host_transitions"
-    build_targets:
-      - "//..."
     test_targets:
       - "//..."
 
@@ -65,22 +41,9 @@ tasks:
       - "--enable_bzlmod"
     build_targets:
       - "//..."
-    test_targets:
-      - "//..."
-
-  bzlmod_windows:
-    name: Bzlmod example - Windows
-    platform: windows
-    working_directory: test/bzlmod
-    environment:
-      # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
-      # when using --incompatible_disable_starlark_host_transitions on Windows
-      BAZELISK_SHUTDOWN: "1"
-    build_flags:
+    test_flags:
       - "--incompatible_disable_starlark_host_transitions"
       - "--enable_bzlmod"
-    build_targets:
-      - "//..."
     test_targets:
       - "//..."
 

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,7 +4,6 @@ matrix:
     - ubuntu1804
     - ubuntu2004
     - macos
-    - windows
 
 tasks:
   build_and_test:
@@ -14,8 +13,20 @@ tasks:
       - "--incompatible_disable_starlark_host_transitions"
     build_targets:
       - "//..."
-    test_flags:
+    test_targets:
+      - "//..."
+
+  build_and_test_windows:
+    name: Build and test - Windows
+    platform: windows
+    environment:
+      # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
+      # when using --incompatible_disable_starlark_host_transitions on Windows
+      BAZELISK_SHUTDOWN: "1"
+    build_flags:
       - "--incompatible_disable_starlark_host_transitions"
+    build_targets:
+      - "//..."
     test_targets:
       - "//..."
 
@@ -27,8 +38,21 @@ tasks:
       - "--incompatible_disable_starlark_host_transitions"
     build_targets:
       - "//..."
-    test_flags:
+    test_targets:
+      - "//..."
+
+  build_and_test_last_green_windows:
+    name: Build and test - Bazel last green - Windows
+    platform: windows
+    bazel: last_green
+    environment:
+      # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
+      # when using --incompatible_disable_starlark_host_transitions on Windows
+      BAZELISK_SHUTDOWN: "1"
+    build_flags:
       - "--incompatible_disable_starlark_host_transitions"
+    build_targets:
+      - "//..."
     test_targets:
       - "//..."
 
@@ -41,9 +65,22 @@ tasks:
       - "--enable_bzlmod"
     build_targets:
       - "//..."
-    test_flags:
+    test_targets:
+      - "//..."
+
+  bzlmod_windows:
+    name: Bzlmod example - Windows
+    platform: windows
+    working_directory: test/bzlmod
+    environment:
+      # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
+      # when using --incompatible_disable_starlark_host_transitions on Windows
+      BAZELISK_SHUTDOWN: "1"
+    build_flags:
       - "--incompatible_disable_starlark_host_transitions"
       - "--enable_bzlmod"
+    build_targets:
+      - "//..."
     test_targets:
       - "//..."
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Release 0.6.2
+
+Bugfix release: bumps `rules_jvm_external` dependency to support building with
+`--incompatible_disable_starlark_host_transitions`
+
+**Contributors**
+
+Alexandre Rostovtsev
+
 ## Release 0.6.1
 
 Bugfix release: fix `rules_jvm_external` pin warnings.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "stardoc",
-    version = "0.6.1",
+    version = "0.6.2",
     compatibility_level = 1,
 )
 

--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of Stardoc."""
 
-version = "0.6.1"
+version = "0.6.2"


### PR DESCRIPTION
Needed for --incompatible_disable_starlark_host_transitions flag flip in Bazel 7

See #180