### PR TITLE
Reorganize CI config to properly fix Windows workaround flags

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -5,13 +5,21 @@ matrix:
     - ubuntu2004
     - macos
 
-.common_flags: !!set &common_flags
+.common_flags: &common_flags
   ? "--incompatible_disable_starlark_host_transitions"
 
-.common_windows_flags: !!set &common_windows_flags
+.bzlmod_flags: &bzlmod_flags
+  <<: *common_flags
+  ? "--enable_bzlmod"
+
+.windows_flags: &windows_flags
   <<: *common_flags
   # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
   ? "--noexperimental_repository_cache_hardlinks"
+
+.windows_bzlmod_flags: &bzlmod_flags
+  <<: *windows_flags
+  ? "--enable_bzlmod"
 
 .common_task_config: &common_task_config
   build_flags: *common_flags
@@ -21,10 +29,20 @@ matrix:
   test_targets:
     - "//..."
 
-.common_windows_task_config: &common_windows_task_config
+.bzlmod_task_config: &bzlmod_task_config
   <<: *common_task_config
-  build_flags: *common_windows_flags
-  test_flags: *common_windows_flags
+  build_flags: *bzlmod_flags
+  test_flags: *bzlmod_flags
+
+.windows_task_config: &windows_task_config
+  <<: *common_task_config
+  build_flags: *windows_flags
+  test_flags: *windows_flags
+
+.windows_bzlmod_task_config: &windows_bzlmod_task_config
+  <<: *common_task_config
+  build_flags: *windows_bzlmod_flags
+  test_flags: *windows_bzlmod_flags
 
 tasks:
   build_and_test:
@@ -33,7 +51,7 @@ tasks:
     platform: ${{ platform }}
 
   build_and_test_windows:
-    <<: *common_windows_task_config
+    <<: *windows_task_config
     name: Build and test - Windows
     platform: windows
 
@@ -44,33 +62,21 @@ tasks:
     bazel: last_green
 
   build_and_test_last_green_windows:
-    <<: *common_windows_task_config
+    <<: *windows_task_config
     name: Build and test - Bazel last green - Windows
     platform: windows
     bazel: last_green
 
   bzlmod:
-    <<: *common_task_config
+    <<: *bzlmod_task_config
     name: Bzlmod example
     platform: ${{ platform }}
     working_directory: test/bzlmod
-    build_flags: !!set
-      <<: *common_flags
-      ? "--enable_bzlmod"
-    test_flags: !!set
-      <<: *common_flags
-      ? "--enable_bzlmod"
 
   bzlmod_windows:
-    <<: *common_windows_task_config
+    <<: *windows_bzlmod_task_config
     name: Bzlmod example - Windows
     platform: windows
     working_directory: test/bzlmod
-    build_flags: !!set
-      <<: *common_windows_flags
-      ? "--enable_bzlmod"
-    test_flags: !!set
-      <<: *common_windows_flags
-      ? "--enable_bzlmod"
 
 buildifier: latest

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -5,10 +5,10 @@ matrix:
     - ubuntu2004
     - macos
 
-.common_flags: &common_flags
+.common_flags: !!set &common_flags
   ? "--incompatible_disable_starlark_host_transitions"
 
-.common_windows_flags: &common_windows_flags
+.common_windows_flags: !!set &common_windows_flags
   <<: *common_flags
   # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
   ? "--noexperimental_repository_cache_hardlinks"
@@ -54,10 +54,10 @@ tasks:
     name: Bzlmod example
     platform: ${{ platform }}
     working_directory: test/bzlmod
-    build_flags:
+    build_flags: !!set
       <<: *common_flags
       ? "--enable_bzlmod"
-    test_flags:
+    test_flags: !!set
       <<: *common_flags
       ? "--enable_bzlmod"
 
@@ -66,10 +66,10 @@ tasks:
     name: Bzlmod example - Windows
     platform: windows
     working_directory: test/bzlmod
-    build_flags:
+    build_flags: !!set
       <<: *common_windows_flags
       ? "--enable_bzlmod"
-    test_flags:
+    test_flags: !!set
       <<: *common_windows_flags
       ? "--enable_bzlmod"
 

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -17,7 +17,7 @@ matrix:
   # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
   ? "--noexperimental_repository_cache_hardlinks"
 
-.windows_bzlmod_flags: &bzlmod_flags
+.windows_bzlmod_flags: &windows_bzlmod_flags
   <<: *windows_flags
   ? "--enable_bzlmod"
 

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -5,75 +5,76 @@ matrix:
     - ubuntu2004
     - macos
 
+.common_flags: &common_flags
+  - "--incompatible_disable_starlark_host_transitions"
+
+.common_windows_flags: &common_windows_flags
+  - *common_flags
+  # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
+  - "--noexperimental_repository_cache_hardlinks"
+
+.common_task_config: &common_task_config
+  build_flags:
+    - *common_flags
+  build_targets:
+    - "//..."
+  test_flags:
+    - *common_flags
+  test_targets:
+    - "//..."
+
+.common_windows_task_config: &common_windows_task_config
+  <<: *common_task_config
+  build_flags:
+    - *common_windows_flags
+  test_flags:
+    - *common_windows_flags
+
 tasks:
   build_and_test:
+    <<: *common_task_config
     name: Build and test
     platform: ${{ platform }}
-    build_flags:
-      - "--incompatible_disable_starlark_host_transitions"
-    build_targets:
-      - "//..."
-    test_targets:
-      - "//..."
 
   build_and_test_windows:
+    <<: *common_windows_task_config
     name: Build and test - Windows
     platform: windows
-    build_flags:
-      - "--incompatible_disable_starlark_host_transitions"
-      # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
-      - "--noexperimental_repository_cache_hardlinks"
-    build_targets:
-      - "//..."
-    test_targets:
-      - "//..."
 
   build_and_test_last_green:
+    <<: *common_task_config
     name: Build and test - Bazel last green
     platform: ${{ platform }}
     bazel: last_green
-    build_flags:
-      - "--incompatible_disable_starlark_host_transitions"
-    build_targets:
-      - "//..."
-    test_targets:
-      - "//..."
 
   build_and_test_last_green_windows:
+    <<: *common_windows_task_config
     name: Build and test - Bazel last green - Windows
     platform: windows
     bazel: last_green
-    build_flags:
-      - "--incompatible_disable_starlark_host_transitions"
-      # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
-      - "--noexperimental_repository_cache_hardlinks"
-    build_targets:
-      - "//..."
-    test_targets:
-      - "//..."
 
   bzlmod:
+    <<: *common_task_config
     name: Bzlmod example
     platform: ${{ platform }}
     working_directory: test/bzlmod
     build_flags:
-      - "--incompatible_disable_starlark_host_transitions"
+      - *common_flags
       - "--enable_bzlmod"
-    build_targets:
-      - "//..."
-    test_targets:
-      - "//..."
+    test_flags:
+      - *common_flags
+      - "--enable_bzlmod"
 
   bzlmod_windows:
+    <<: *common_windows_task_config
     name: Bzlmod example - Windows
     platform: windows
     working_directory: test/bzlmod
     build_flags:
-      - "--incompatible_disable_starlark_host_transitions"
+      - *common_windows_flags
       - "--enable_bzlmod"
-    build_targets:
-      - "//..."
-    test_targets:
-      - "//..."
+    test_flags:
+      - *common_windows_flags
+      - "--enable_bzlmod"
 
 buildifier: latest

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,29 +6,25 @@ matrix:
     - macos
 
 .common_flags: &common_flags
-  - "--incompatible_disable_starlark_host_transitions"
+  ? "--incompatible_disable_starlark_host_transitions"
 
 .common_windows_flags: &common_windows_flags
-  - *common_flags
+  <<: *common_flags
   # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
-  - "--noexperimental_repository_cache_hardlinks"
+  ? "--noexperimental_repository_cache_hardlinks"
 
 .common_task_config: &common_task_config
-  build_flags:
-    - *common_flags
+  build_flags: *common_flags
   build_targets:
     - "//..."
-  test_flags:
-    - *common_flags
+  test_flags: *common_flags
   test_targets:
     - "//..."
 
 .common_windows_task_config: &common_windows_task_config
   <<: *common_task_config
-  build_flags:
-    - *common_windows_flags
-  test_flags:
-    - *common_windows_flags
+  build_flags: *common_windows_flags
+  test_flags: *common_windows_flags
 
 tasks:
   build_and_test:
@@ -59,11 +55,11 @@ tasks:
     platform: ${{ platform }}
     working_directory: test/bzlmod
     build_flags:
-      - *common_flags
-      - "--enable_bzlmod"
+      <<: *common_flags
+      ? "--enable_bzlmod"
     test_flags:
-      - *common_flags
-      - "--enable_bzlmod"
+      <<: *common_flags
+      ? "--enable_bzlmod"
 
   bzlmod_windows:
     <<: *common_windows_task_config
@@ -71,10 +67,10 @@ tasks:
     platform: windows
     working_directory: test/bzlmod
     build_flags:
-      - *common_windows_flags
-      - "--enable_bzlmod"
+      <<: *common_windows_flags
+      ? "--enable_bzlmod"
     test_flags:
-      - *common_windows_flags
-      - "--enable_bzlmod"
+      <<: *common_windows_flags
+      ? "--enable_bzlmod"
 
 buildifier: latest


### PR DESCRIPTION
Use shared nodes for flags and task configs to avoid copy-pasting