### PR TITLE
Disable Bzlmod explicitly in .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,6 @@
 build --java_language_version=11
 build --tool_java_language_version=11
+
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/stardoc/issues/189
+common --noenable_bzlmod


### PR DESCRIPTION
This will help make sure [Bazel Downstream Pipeline](https://github.com/bazelbuild/continuous-integration/blob/master/docs/downstream-testing.md) is green after enabling Bzlmod at Bazel@HEAD

See https://github.com/bazelbuild/bazel/issues/18958#issuecomment-1749058780

Related https://github.com/bazelbuild/stardoc/issues/189