### PR TITLE
Load PyInfo from rules_python

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -226,6 +226,10 @@ stardoc_test(
     golden_file = "testdata/py_rule_test/golden.md",
     input_file = "testdata/py_rule_test/input.bzl",
     symbol_names = ["py_related_rule"],
+    deps = [
+        "@rules_python//docs:bazel_repo_tools",
+        "@rules_python//python:py_info_bzl",
+    ],
 )
 
 stardoc_test(
@@ -247,6 +251,8 @@ stardoc_test(
     input_file = "testdata/providers_for_attributes_test/input.bzl",
     deps = [
         "testdata/providers_for_attributes_test/dep.bzl",
+        "@rules_python//docs:bazel_repo_tools",
+        "@rules_python//python:py_info_bzl",
     ],
 )
 

--- a/test/testdata/providers_for_attributes_test/input.bzl
+++ b/test/testdata/providers_for_attributes_test/input.bzl
@@ -1,5 +1,6 @@
 """The input file for the providers for attributes test"""
 
+load("@rules_python//python:py_info.bzl", "PyInfo")
 load(":testdata/providers_for_attributes_test/dep.bzl", "DepProviderInfo")
 
 def my_rule_impl(ctx):

--- a/test/testdata/py_rule_test/input.bzl
+++ b/test/testdata/py_rule_test/input.bzl
@@ -1,5 +1,7 @@
 """The input file for the python rule test"""
 
+load("@rules_python//python:py_info.bzl", "PyInfo")
+
 def exercise_the_api():
     var1 = PyRuntimeInfo  # @unused
     var2 = PyInfo  # @unused


### PR DESCRIPTION
This ensures the correct symbol is used as Bazel/rules_python transition off the builtin symbols.