### PR TITLE
Regenerate bundled legacy jar and proto for Bazel 7.0.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 # Needed for generating the Stardoc release binary.
 git_repository(
     name = "io_bazel",
-    commit = "1f15b87b6cf0474ade552284db70b42606f0e3ba",  # 2023-08-07
+    commit = "ff36d875b9b236ad141dce40e65cae5f4ffbfdcb",  # Bazel 7.0.1 - 2024-01-18
     patch_cmds = [
         # Used by update-release-binary.sh for vendoring files from @io_bazel
         "git log -n 1 --format=%H > .io_bazel.sha",

--- a/stardoc/proto/stardoc_output.proto
+++ b/stardoc/proto/stardoc_output.proto
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 // Vendored from src/main/java/com/google/devtools/build/skydoc/rendering/proto/stardoc_output.proto
-// in the Bazel source tree at commit e33c2d14728aea6914b165fe11f08ff4982196ca
+// in the Bazel source tree at commit bf5504a8c8f2d5e91acb18db864b2dae0d90ca7f
 //
 // Protos for Stardoc data.
 //
@@ -85,16 +85,23 @@ message RuleInfo {
   // The attributes of the rule.
   repeated AttributeInfo attribute = 3;
 
+  // Note: legacy Stardoc (0.5.x and earlier) does not set any fields below.
+
   // The module where and the name under which the rule was originally declared.
-  //
-  // Note: legacy Stardoc (0.5.x and earlier) does not set this field.
   OriginKey origin_key = 4;
 
   // The list of providers that the rule's implementation must return. Unset if
   // the rule lists no advertised providers.
-  //
-  // Note: legacy Stardoc (0.5.x and earlier) does not set this field.
   ProviderNameGroup advertised_providers = 5;
+
+  // True if this is a test rule.
+  bool test = 6;
+
+  // True if this is an executable rule.
+  //
+  // Note: if test is true, executable is also true (test rules are implicitly
+  // executable).
+  bool executable = 7;
 }
 
 // Representation of a Starlark rule, repository rule, or module extension tag
@@ -127,6 +134,9 @@ message AttributeInfo {
 
   // The string representation of the default value of this attribute.
   string default_value = 6;
+
+  // If true, the attribute is non-configurable.
+  bool nonconfigurable = 7;
 }
 
 // Representation of a set of providers.
@@ -234,11 +244,14 @@ message ProviderInfo {
   // The fields of the provider.
   repeated ProviderFieldInfo field_info = 3;
 
+  // Note: legacy Stardoc (0.5.x and earlier) does not set any fields below.
+
   // The module where and the name under which the provider was originally
   // declared.
-  //
-  // Note: legacy Stardoc (0.5.x and earlier) does not set this field.
   OriginKey origin_key = 4;
+
+  // The provider's init callback.
+  StarlarkFunctionInfo init = 5;
 }
 
 // Representation of a Starlark aspect definition.

--- a/test/testdata/function_wrap_multiple_lines_test/legacy_golden.md
+++ b/test/testdata/function_wrap_multiple_lines_test/legacy_golden.md
@@ -21,7 +21,7 @@ Runs [ANTLR 3](https://www.antlr3.org//) on a set of grammars.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="antlr-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="antlr-deps"></a>deps |  The dependencies to use. Defaults to the most recent ANTLR 3 release, but if you need to use a different version, you can specify the dependencies here.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[Label("@antlr3_runtimes//:tool")]`  |
+| <a id="antlr-deps"></a>deps |  The dependencies to use. Defaults to the most recent ANTLR 3 release, but if you need to use a different version, you can specify the dependencies here.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[Label("@@antlr3_runtimes//:tool")]`  |
 | <a id="antlr-srcs"></a>srcs |  The grammar files to process.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="antlr-Xconversiontimeout"></a>Xconversiontimeout |  Set NFA conversion timeout for each decision.   | Integer | optional |  `0`  |
 | <a id="antlr-Xdbgconversion"></a>Xdbgconversion |  Dump lots of info during NFA conversion.   | Boolean | optional |  `False`  |


### PR DESCRIPTION
Required for the Stardoc's legacy doc extractor to behave consistently with Bazel 7 when stringifying @@-prefixed labels - see https://github.com/bazelbuild/bazel/issues/18543

Subsumes https://github.com/bazelbuild/stardoc/pull/193