### PR TITLE
Stop explicitly testing PyInfo - it's becoming an ordinary Starlark provider

### DIFF
--- a/test/testdata/providers_for_attributes_test/input.bzl
+++ b/test/testdata/providers_for_attributes_test/input.bzl
@@ -25,7 +25,7 @@ my_rule = rule(
     doc = "This rule does things.",
     attrs = {
         "first": attr.label_keyed_string_dict(
-            providers = [MyProviderInfo, PyInfo, cc_common.CcToolchainInfo],
+            providers = [MyProviderInfo, cc_common.CcToolchainInfo],
             doc = "this is the first attribute.",
         ),
         "second": attr.label_list(

--- a/test/testdata/py_rule_test/input.bzl
+++ b/test/testdata/py_rule_test/input.bzl
@@ -2,7 +2,6 @@
 
 def exercise_the_api():
     var1 = PyRuntimeInfo  # @unused
-    var2 = PyInfo  # @unused
 
 exercise_the_api()
 


### PR DESCRIPTION
We were explicitly testing it until now only because it was a builtin provider; we already have sufficient test coverage for Starlark providers.

Alternative to https://github.com/bazelbuild/stardoc/pull/194