### PR TITLE
trivial: Remove unused visibility spec

### DIFF
--- a/src/main/java/com/google/devtools/build/skydoc/renderer/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/renderer/BUILD
@@ -1,12 +1,6 @@
 load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 
-package(
-    default_applicable_licenses = ["//:license"],
-    default_visibility = [
-        "//src:__subpackages__",
-        "//stardoc:__subpackages__",
-    ],
-)
+package(default_applicable_licenses = ["//:license"])
 
 filegroup(
     name = "srcs",


### PR DESCRIPTION
Identified by internal linter.