### PR TITLE
trivial: Remove another unused visibility spec

### DIFF
--- a/src/main/java/com/google/devtools/build/skydoc/rendering/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/rendering/BUILD
@@ -2,10 +2,7 @@ load("@rules_java//java:defs.bzl", "java_library")
 
 package(
     default_applicable_licenses = ["//:license"],
-    default_visibility = [
-        "//src:__subpackages__",
-        "//stardoc:__subpackages__",
-    ],
+    default_visibility = ["//src:__subpackages__"],
 )
 
 filegroup(


### PR DESCRIPTION
Identified by internal linter.