### PR TITLE
Fix repo rules environment variables list

### DIFF
--- a/stardoc/templates/markdown_tables/repository_rule.vm
+++ b/stardoc/templates/markdown_tables/repository_rule.vm
@@ -25,6 +25,7 @@ ${ruleInfo.docString}
 **ENVIRONMENT VARIABLES**
 
 This repository rule depends on the following environment variables:
+
 #foreach ($var in $ruleInfo.getEnvironList())
 * ${util.markdownCodeSpan($var)}
 #end


### PR DESCRIPTION
Add a newline before repo rules list of environment variable dependencies so that the list correctly renders.