### PR TITLE
Remove trailing space from stamping test, and filter it from update-stardoc-tests.sh script

### DIFF
--- a/test/testdata/stamping_test/golden.md
+++ b/test/testdata/stamping_test/golden.md
@@ -1,7 +1,7 @@
 This Stardoc was built in the `AD` era.
 
-Host empty: false
+Host empty: `false`.
 
-This key does not exist: 
+This key does not exist: ``.
 
 

--- a/test/testdata/stamping_test/stamping_header.vm
+++ b/test/testdata/stamping_test/stamping_header.vm
@@ -3,9 +3,9 @@
 This Stardoc was built in the `$util.formatBuildTimestamp($stamping.volatile.BUILD_TIMESTAMP, "UTC", "G")` era.
 
 ## Should test a stable value, but stable contains quasi sensitive info, so don't print that in the test output
-Host empty: $stamping.stable.BUILD_HOST.isEmpty()
+Host empty: `$stamping.stable.BUILD_HOST.isEmpty()`.
 
 ## Sometimes Stardoc is built without --workspace_status_command (e.g. in build tests), luckily "$!foo" will tell
 ## Velocity to ignore null values:
-This key does not exist: $!stamping.stable.STABLE_GIT_COMMIT
+This key does not exist: `$!stamping.stable.STABLE_GIT_COMMIT`.
 

--- a/update-stardoc-tests.sh
+++ b/update-stardoc-tests.sh
@@ -44,7 +44,7 @@ fi
 
 # Some tests cannot be automatically regenerated using this script, as they don't fall under the normal
 # golden test pattern
-EXCLUDED_TESTS="namespace_test_with_allowlist|multi_level_namespace_test_with_allowlist|local_repository_test"
+EXCLUDED_TESTS="namespace_test_with_allowlist|multi_level_namespace_test_with_allowlist|local_repository_test|stamping_with_stamping_off"
 echo "** Querying for tests..."
 regen_legacy_targets=$(${BAZEL} query //test:all | grep regenerate_with_jar | grep -vE "_golden_stardoc|$EXCLUDED_TESTS")
 regen_starlark_doc_extract_targets=$(${BAZEL} query //test:all | grep regenerate_ | grep -vE "_legacy|_golden\.extract|$EXCLUDED_TESTS")


### PR DESCRIPTION
Internal linter complains about trailing spaces