### PR TITLE
ImmutableMap.Builder.build() is deprecated

### DIFF
--- a/src/main/java/com/google/devtools/build/skydoc/rendering/Stamping.java
+++ b/src/main/java/com/google/devtools/build/skydoc/rendering/Stamping.java
@@ -42,7 +42,7 @@ public final class Stamping {
       String[] kv = line.split(" ", 2); // split on first space only
       builder.put(kv[0], kv[1]);
     }
-    return builder.build();
+    return builder.buildKeepingLast();
   }
 
   private Stamping(


### PR DESCRIPTION
... and we probably want buildKeepingLast to avoid unnecessary brittleness.

Fixes internal linter complaints.