### PR TITLE
Give LICENSE file export public visibility

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,7 +12,7 @@ licenses(["notice"])
 
 exports_files(
     ["LICENSE"],
-    ["//visibility:public"],
+    visibility = ["//visibility:public"],
 )
 
 # Inputs for distro transformations and consistency tests.

--- a/BUILD
+++ b/BUILD
@@ -10,10 +10,14 @@ license(
 
 licenses(["notice"])
 
+exports_files(
+    ["LICENSE"],
+    ["//visibility:public"],
+)
+
 # Inputs for distro transformations and consistency tests.
 exports_files(
     [
-        "LICENSE",
         "WORKSPACE",
         "MODULE.bazel",
         "deps.bzl",


### PR DESCRIPTION
Required by internal license compliance checks.