### PR TITLE
Use new host platform constraints in test/bzlmod

### DIFF
--- a/test/bzlmod/BUILD
+++ b/test/bzlmod/BUILD
@@ -11,8 +11,8 @@ stardoc(
     out = "docs.md",
     input = "def.bzl",
     deps = [
-        "@local_config_platform//:constraints.bzl",
         "@my_skylib//rules:write_file",
+        "@platforms//host:constraints_lib",
     ],
 )
 

--- a/test/bzlmod/MODULE.bazel
+++ b/test/bzlmod/MODULE.bazel
@@ -4,8 +4,5 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(
-    name = "bazel_skylib",
-    version = "1.4.0",
-    repo_name = "my_skylib",
-)
+bazel_dep(name = "bazel_skylib", version = "1.6.1", repo_name = "my_skylib")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/test/bzlmod/def.bzl
+++ b/test/bzlmod/def.bzl
@@ -14,8 +14,8 @@
 
 """A simple macro used to test stardoc."""
 
-load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")
 load("@my_skylib//rules:write_file.bzl", "write_file")
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 
 def write_host_constraints(name):
     """Emits the constraints of the host platform to a file.


### PR DESCRIPTION
Fixes the Stardoc part of https://github.com/bazelbuild/bazel/issues/21877.