### PR TITLE
Include `load` in summaries

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -35,15 +35,11 @@ matrix:
     - "//test/..."
   test_flags: *noenable_bzlmod_flags
   test_targets:
-  # Some tests are expected to fail in legacy WORKSPACE mode due to repo name change
-    - "//test/..."
-    - "-//test:attribute_defaults_test"
-    - "-//test:function_wrap_multiple_lines_test"
-    - "-//test:misc_apis_test"
-    - "-//test:module_extension_test"
-    - "-//test:proto_format_test"
-    - "-//test:stardoc_self_gen_test"
-    - "-//test:table_of_contents_test"
+  # Most tests will not pass in legacy WORKSPACE mode due to repo name change
+    - "//test:multiple_files_noenable_bzlmod_test"
+    - "//test:same_level_file_noenable_bzlmod_test"
+    - "//test:table_of_contents_noenable_bzlmod_test"
+    - "//test:local_repository_test"
 
 .windows_task_config: &windows_task_config
   <<: *common_task_config
@@ -61,7 +57,7 @@ tasks:
     name: Build and test - Windows
     platform: windows
 
-  legacy_workspace:
+  noenable_bzlmod:
     <<: *noenable_bzlmod_task_config
     name: Build and test - legacy WORKSPACE setup
     platform: ${{ platform }}

--- a/docs/stardoc_rule.md
+++ b/docs/stardoc_rule.md
@@ -8,6 +8,7 @@ Starlark rule for stardoc: a documentation generator tool written in Java.
 
 <pre>
 load("@stardoc//stardoc:stardoc.bzl", "stardoc")
+
 stardoc(<a href="#stardoc-name">name</a>, <a href="#stardoc-input">input</a>, <a href="#stardoc-out">out</a>, <a href="#stardoc-deps">deps</a>, <a href="#stardoc-format">format</a>, <a href="#stardoc-symbol_names">symbol_names</a>, <a href="#stardoc-renderer">renderer</a>, <a href="#stardoc-aspect_template">aspect_template</a>, <a href="#stardoc-func_template">func_template</a>,
         <a href="#stardoc-header_template">header_template</a>, <a href="#stardoc-table_of_contents_template">table_of_contents_template</a>, <a href="#stardoc-provider_template">provider_template</a>, <a href="#stardoc-rule_template">rule_template</a>,
         <a href="#stardoc-repository_rule_template">repository_rule_template</a>, <a href="#stardoc-module_extension_template">module_extension_template</a>, <a href="#stardoc-footer_template">footer_template</a>, <a href="#stardoc-render_main_repo_name">render_main_repo_name</a>,

--- a/docs/stardoc_rule.md
+++ b/docs/stardoc_rule.md
@@ -7,6 +7,7 @@ Starlark rule for stardoc: a documentation generator tool written in Java.
 ## stardoc
 
 <pre>
+load("@stardoc//stardoc:stardoc.bzl", "stardoc")
 stardoc(<a href="#stardoc-name">name</a>, <a href="#stardoc-input">input</a>, <a href="#stardoc-out">out</a>, <a href="#stardoc-deps">deps</a>, <a href="#stardoc-format">format</a>, <a href="#stardoc-symbol_names">symbol_names</a>, <a href="#stardoc-renderer">renderer</a>, <a href="#stardoc-aspect_template">aspect_template</a>, <a href="#stardoc-func_template">func_template</a>,
         <a href="#stardoc-header_template">header_template</a>, <a href="#stardoc-table_of_contents_template">table_of_contents_template</a>, <a href="#stardoc-provider_template">provider_template</a>, <a href="#stardoc-rule_template">rule_template</a>,
         <a href="#stardoc-repository_rule_template">repository_rule_template</a>, <a href="#stardoc-module_extension_template">module_extension_template</a>, <a href="#stardoc-footer_template">footer_template</a>, <a href="#stardoc-render_main_repo_name">render_main_repo_name</a>,

--- a/src/main/java/com/google/devtools/build/stardoc/renderer/RendererMain.java
+++ b/src/main/java/com/google/devtools/build/stardoc/renderer/RendererMain.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Main entry point for Renderer binary.
@@ -91,7 +92,9 @@ public final class RendererMain {
               rendererOptions.aspectTemplateFilePath,
               rendererOptions.repositoryRuleTemplateFilePath,
               rendererOptions.moduleExtensionTemplateFilePath,
-              !moduleInfo.getFile().isEmpty() ? moduleInfo.getFile() : "...",
+              !moduleInfo.getFile().isEmpty()
+                  ? Optional.of(moduleInfo.getFile())
+                  : Optional.empty(),
               rendererOptions.footerTemplateFilePath,
               stamping);
 

--- a/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownRenderer.java
+++ b/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownRenderer.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Optional;
 
 /** Produces stardoc output in markdown form. */
 public class MarkdownRenderer {
@@ -53,7 +54,7 @@ public class MarkdownRenderer {
   private final String aspectTemplateFilename;
   private final String repositoryRuleTemplateFilename;
   private final String moduleExtensionTemplateFilename;
-  private final String extensionBzlFile;
+  private final Optional<String> entrypointBzlFile;
   private final String footerTemplateFilename;
   private final Stamping stamping;
 
@@ -66,7 +67,7 @@ public class MarkdownRenderer {
       String aspectTemplate,
       String repositoryRuleTemplate,
       String moduleExtensionTemplate,
-      String extensionBzlFile,
+      Optional<String> entrypointBzlFile,
       String footerTemplate,
       Stamping stamping) {
     this.headerTemplateFilename = headerTemplate;
@@ -77,7 +78,7 @@ public class MarkdownRenderer {
     this.aspectTemplateFilename = aspectTemplate;
     this.repositoryRuleTemplateFilename = repositoryRuleTemplate;
     this.moduleExtensionTemplateFilename = moduleExtensionTemplate;
-    this.extensionBzlFile = extensionBzlFile;
+    this.entrypointBzlFile = entrypointBzlFile;
     this.footerTemplateFilename = footerTemplate;
     this.stamping = stamping;
   }
@@ -90,7 +91,7 @@ public class MarkdownRenderer {
     ImmutableMap<String, Object> vars =
         ImmutableMap.of(
             "util",
-            new MarkdownUtil(extensionBzlFile),
+            new MarkdownUtil(entrypointBzlFile),
             "moduleDocstring",
             moduleInfo.getModuleDocstring(),
             "stamping",
@@ -118,7 +119,7 @@ public class MarkdownRenderer {
 
     ImmutableMap<String, Object> vars =
         ImmutableMap.of(
-            "util", new MarkdownUtil(extensionBzlFile),
+            "util", new MarkdownUtil(entrypointBzlFile),
             "ruleInfos", ruleInfos,
             "providerInfos", providerInfos,
             "functionInfos", starlarkFunctions,
@@ -141,7 +142,7 @@ public class MarkdownRenderer {
     ImmutableMap<String, Object> vars =
         ImmutableMap.of(
             "util",
-            new MarkdownUtil(extensionBzlFile),
+            new MarkdownUtil(entrypointBzlFile),
             "ruleName",
             ruleInfo.getRuleName(),
             "ruleInfo",
@@ -162,7 +163,7 @@ public class MarkdownRenderer {
     ImmutableMap<String, Object> vars =
         ImmutableMap.of(
             "util",
-            new MarkdownUtil(extensionBzlFile),
+            new MarkdownUtil(entrypointBzlFile),
             "providerName",
             providerInfo.getProviderName(),
             "providerInfo",
@@ -181,7 +182,7 @@ public class MarkdownRenderer {
    */
   public String render(StarlarkFunctionInfo functionInfo) throws IOException {
     ImmutableMap<String, Object> vars =
-        ImmutableMap.of("util", new MarkdownUtil(extensionBzlFile), "funcInfo", functionInfo);
+        ImmutableMap.of("util", new MarkdownUtil(entrypointBzlFile), "funcInfo", functionInfo);
     Reader reader = readerFromPath(functionTemplateFilename);
     try {
       return Template.parseFrom(reader).evaluate(vars);
@@ -198,7 +199,7 @@ public class MarkdownRenderer {
     ImmutableMap<String, Object> vars =
         ImmutableMap.of(
             "util",
-            new MarkdownUtil(extensionBzlFile),
+            new MarkdownUtil(entrypointBzlFile),
             "aspectName",
             aspectInfo.getAspectName(),
             "aspectInfo",
@@ -219,7 +220,7 @@ public class MarkdownRenderer {
     ImmutableMap<String, Object> vars =
         ImmutableMap.of(
             "util",
-            new MarkdownUtil(extensionBzlFile),
+            new MarkdownUtil(entrypointBzlFile),
             "ruleName",
             repositoryRuleInfo.getRuleName(),
             "ruleInfo",
@@ -240,7 +241,7 @@ public class MarkdownRenderer {
     ImmutableMap<String, Object> vars =
         ImmutableMap.of(
             "util",
-            new MarkdownUtil(extensionBzlFile),
+            new MarkdownUtil(entrypointBzlFile),
             "extensionName",
             moduleExtensionInfo.getExtensionName(),
             "extensionInfo",
@@ -256,7 +257,7 @@ public class MarkdownRenderer {
   /** Returns a markdown header string that should appear at the end of Stardoc's output. */
   public String renderMarkdownFooter(ModuleInfo moduleInfo) throws IOException {
     ImmutableMap<String, Object> vars =
-        ImmutableMap.of("util", new MarkdownUtil(extensionBzlFile), "stamping", stamping);
+        ImmutableMap.of("util", new MarkdownUtil(entrypointBzlFile), "stamping", stamping);
     Reader reader = readerFromPath(footerTemplateFilename);
     try {
       return Template.parseFrom(reader).evaluate(vars);

--- a/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownUtil.java
+++ b/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownUtil.java
@@ -219,7 +219,7 @@ public final class MarkdownUtil {
   public String ruleSummary(String ruleName, RuleInfo ruleInfo) {
     ImmutableList<String> attributeNames =
         ruleInfo.getAttributeList().stream().map(AttributeInfo::getName).collect(toImmutableList());
-    return maybeLoad(ruleName) + summary(ruleName, attributeNames);
+    return summary(ruleName, attributeNames);
   }
 
   /**
@@ -233,7 +233,7 @@ public final class MarkdownUtil {
         providerInfo.getFieldInfoList().stream()
             .map(StardocOutputProtos.ProviderFieldInfo::getName)
             .collect(toImmutableList());
-    return maybeLoad(providerName) + summary(providerName, fieldNames);
+    return summary(providerName, fieldNames);
   }
 
   /**
@@ -247,16 +247,7 @@ public final class MarkdownUtil {
         aspectInfo.getAttributeList().stream()
             .map(AttributeInfo::getName)
             .collect(toImmutableList());
-    String aspectFlag =
-        entrypointBzlFile
-            // Namespaced aspects can't be referenced on the command line.
-            .filter(unused -> !aspectName.contains("."))
-            .map(
-                file ->
-                    String.format(
-                        "# or on the command line:\n# --aspects=%s%%%s\n", file, aspectName))
-            .orElse("");
-    return maybeLoad(aspectName) + aspectFlag + summary(aspectName, attributeNames);
+    return summary(aspectName, attributeNames);
   }
 
   /**
@@ -270,7 +261,7 @@ public final class MarkdownUtil {
   public String repositoryRuleSummary(String ruleName, RepositoryRuleInfo ruleInfo) {
     ImmutableList<String> attributeNames =
         ruleInfo.getAttributeList().stream().map(AttributeInfo::getName).collect(toImmutableList());
-    return maybeLoad(ruleName) + summary(ruleName, attributeNames);
+    return summary(ruleName, attributeNames);
   }
 
   /**
@@ -319,12 +310,13 @@ public final class MarkdownUtil {
         funcInfo.getParameterList().stream()
             .map(FunctionParamInfo::getName)
             .collect(toImmutableList());
-    return maybeLoad(funcInfo.getFunctionName()) + summary(funcInfo.getFunctionName(), paramNames);
+    return summary(funcInfo.getFunctionName(), paramNames);
   }
 
-  private String maybeLoad(String name) {
+  @SuppressWarnings("unused") // Used by markdown template.
+  public String loadStatement(String name) {
     return entrypointBzlFile
-        .map(file -> String.format("load(\"%s\", \"%s\")\n", file, name.split("\\.")[0]))
+        .map(file -> String.format("load(\"%s\", \"%s\")", file, name.split("\\.")[0]))
         .orElse("");
   }
 

--- a/src/test/java/com/google/devtools/build/stardoc/rendering/MarkdownUtilTest.java
+++ b/src/test/java/com/google/devtools/build/stardoc/rendering/MarkdownUtilTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.stardoc.rendering;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -24,7 +25,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MarkdownUtilTest {
 
-  MarkdownUtil util = new MarkdownUtil("//:test.bzl");
+  MarkdownUtil util = new MarkdownUtil(Optional.of("//:test.bzl"));
 
   @Test
   public void markdownCodeSpan() {

--- a/stardoc/templates/html_tables/aspect.vm
+++ b/stardoc/templates/html_tables/aspect.vm
@@ -3,6 +3,8 @@
 #[[##]]# ${aspectName}
 
 <pre>
+${util.loadStatement($aspectName)}
+
 ${util.aspectSummary($aspectName, $aspectInfo)}
 </pre>
 

--- a/stardoc/templates/html_tables/func.vm
+++ b/stardoc/templates/html_tables/func.vm
@@ -3,6 +3,8 @@
 #[[##]]# ${funcInfo.functionName}
 
 <pre>
+${util.loadStatement($funcInfo.functionName)}
+
 ${util.funcSummary($funcInfo)}
 </pre>
 

--- a/stardoc/templates/html_tables/provider.vm
+++ b/stardoc/templates/html_tables/provider.vm
@@ -8,14 +8,11 @@
 #[[##]]# ${providerName}
 
 <pre>
-<<<<<<< HEAD
 ${util.loadStatement($providerName)}
 
-=======
 #if ($providerInfo.hasInit() && !$mergeParamsAndFields)
 ${util.providerSummaryWithInitAnchor($providerName, $providerInfo)}
 #else
->>>>>>> origin/master
 ${util.providerSummary($providerName, $providerInfo)}
 #end
 </pre>

--- a/stardoc/templates/html_tables/provider.vm
+++ b/stardoc/templates/html_tables/provider.vm
@@ -3,6 +3,8 @@
 #[[##]]# ${providerName}
 
 <pre>
+${util.loadStatement($providerName)}
+
 ${util.providerSummary($providerName, $providerInfo)}
 </pre>
 

--- a/stardoc/templates/html_tables/repository_rule.vm
+++ b/stardoc/templates/html_tables/repository_rule.vm
@@ -3,6 +3,8 @@
 #[[##]]# ${ruleName}
 
 <pre>
+${util.loadStatement($ruleName)}
+
 ${util.repositoryRuleSummary($ruleName, $ruleInfo)}
 </pre>
 #if (!$ruleInfo.docString.isEmpty())

--- a/stardoc/templates/html_tables/rule.vm
+++ b/stardoc/templates/html_tables/rule.vm
@@ -3,6 +3,8 @@
 #[[##]]# ${ruleName}
 
 <pre>
+${util.loadStatement($ruleName)}
+
 ${util.ruleSummary($ruleName, $ruleInfo)}
 </pre>
 

--- a/stardoc/templates/markdown_tables/aspect.vm
+++ b/stardoc/templates/markdown_tables/aspect.vm
@@ -3,6 +3,8 @@
 #[[##]]# ${aspectName}
 
 <pre>
+${util.loadStatement($aspectName)}
+
 ${util.aspectSummary($aspectName, $aspectInfo)}
 </pre>
 

--- a/stardoc/templates/markdown_tables/func.vm
+++ b/stardoc/templates/markdown_tables/func.vm
@@ -3,6 +3,8 @@
 #[[##]]# ${funcInfo.functionName}
 
 <pre>
+${util.loadStatement($funcInfo.functionName)}
+
 ${util.funcSummary($funcInfo)}
 </pre>
 

--- a/stardoc/templates/markdown_tables/provider.vm
+++ b/stardoc/templates/markdown_tables/provider.vm
@@ -3,6 +3,8 @@
 #[[##]]# ${providerName}
 
 <pre>
+${util.loadStatement($providerName)}
+
 ${util.providerSummary($providerName, $providerInfo)}
 </pre>
 

--- a/stardoc/templates/markdown_tables/repository_rule.vm
+++ b/stardoc/templates/markdown_tables/repository_rule.vm
@@ -3,6 +3,8 @@
 #[[##]]# ${ruleName}
 
 <pre>
+${util.loadStatement($ruleName)}
+
 ${util.repositoryRuleSummary($ruleName, $ruleInfo)}
 </pre>
 #if (!$ruleInfo.docString.isEmpty())

--- a/stardoc/templates/markdown_tables/rule.vm
+++ b/stardoc/templates/markdown_tables/rule.vm
@@ -3,6 +3,8 @@
 #[[##]]# ${ruleName}
 
 <pre>
+${util.loadStatement($ruleName)}
+
 ${util.ruleSummary($ruleName, $ruleInfo)}
 </pre>
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -120,10 +120,38 @@ stardoc_test(
 )
 
 stardoc_test(
+    name = "multiple_files_noenable_bzlmod_test",
+    golden_file = "testdata/multiple_files_test/noenable_bzlmod_golden.md",
+    input_file = "testdata/multiple_files_test/input.bzl",
+    tags = [
+        "noenable_bzlmod",
+        "manual",
+    ],
+    deps = [
+        "testdata/multiple_files_test/dep.bzl",
+        "testdata/multiple_files_test/inner_dep.bzl",
+    ],
+)
+
+stardoc_test(
     name = "same_level_file_test",
     golden_file = "//test/testdata/same_level_file_test:golden.md",
     input_file = "//test/testdata/same_level_file_test:input.bzl",
     symbol_names = ["my_rule"],
+    deps = [
+        "//test/testdata/same_level_file_test:dep.bzl",
+    ],
+)
+
+stardoc_test(
+    name = "same_level_file_noenable_bzlmod_test",
+    golden_file = "//test/testdata/same_level_file_test:noenable_bzlmod_golden.md",
+    input_file = "//test/testdata/same_level_file_test:input.bzl",
+    symbol_names = ["my_rule"],
+    tags = [
+        "noenable_bzlmod",
+        "manual",
+    ],
     deps = [
         "//test/testdata/same_level_file_test:dep.bzl",
     ],
@@ -307,6 +335,18 @@ stardoc_test(
 )
 
 stardoc_test(
+    name = "table_of_contents_noenable_bzlmod_test",
+    golden_file = "testdata/table_of_contents_test/noenable_bzlmod_golden.md",
+    input_file = "testdata/table_of_contents_test/input.bzl",
+    table_of_contents_template = "//stardoc:templates/markdown_tables/table_of_contents.vm",
+    tags = [
+        "noenable_bzlmod",
+        "manual",
+    ],
+    deps = [":table_of_contents_test_deps"],
+)
+
+stardoc_test(
     name = "stamping_test",
     golden_file = "testdata/stamping_test/golden.md",
     header_template = "testdata/stamping_test/stamping_header.vm",
@@ -323,7 +363,7 @@ stardoc_test(
 )
 
 sh_test(
-    name = "local_repository_test_e2e_test",
+    name = "local_repository_test",
     srcs = ["diff_test_runner.sh"],
     args = [
         "$(location @local_repository_test//:output.md)",

--- a/test/BUILD
+++ b/test/BUILD
@@ -124,8 +124,8 @@ stardoc_test(
     golden_file = "testdata/multiple_files_test/noenable_bzlmod_golden.md",
     input_file = "testdata/multiple_files_test/input.bzl",
     tags = [
-        "noenable_bzlmod",
         "manual",
+        "noenable_bzlmod",
     ],
     deps = [
         "testdata/multiple_files_test/dep.bzl",
@@ -149,8 +149,8 @@ stardoc_test(
     input_file = "//test/testdata/same_level_file_test:input.bzl",
     symbol_names = ["my_rule"],
     tags = [
-        "noenable_bzlmod",
         "manual",
+        "noenable_bzlmod",
     ],
     deps = [
         "//test/testdata/same_level_file_test:dep.bzl",
@@ -340,8 +340,8 @@ stardoc_test(
     input_file = "testdata/table_of_contents_test/input.bzl",
     table_of_contents_template = "//stardoc:templates/markdown_tables/table_of_contents.vm",
     tags = [
-        "noenable_bzlmod",
         "manual",
+        "noenable_bzlmod",
     ],
     deps = [":table_of_contents_test_deps"],
 )

--- a/test/bzlmod/MODULE.bazel
+++ b/test/bzlmod/MODULE.bazel
@@ -1,4 +1,5 @@
 module(name = "test_module")
+
 bazel_dep(name = "stardoc", version = "")
 local_path_override(
     module_name = "stardoc",

--- a/test/bzlmod/MODULE.bazel
+++ b/test/bzlmod/MODULE.bazel
@@ -1,3 +1,4 @@
+module(name = "test_module")
 bazel_dep(name = "stardoc", version = "")
 local_path_override(
     module_name = "stardoc",

--- a/test/bzlmod/docs.md.golden
+++ b/test/bzlmod/docs.md.golden
@@ -7,7 +7,7 @@ A simple macro used to test stardoc.
 ## write_host_constraints
 
 <pre>
-load("@//:def.bzl", "write_host_constraints")
+load("@test_module//:def.bzl", "write_host_constraints")
 
 write_host_constraints(<a href="#write_host_constraints-name">name</a>)
 </pre>

--- a/test/bzlmod/docs.md.golden
+++ b/test/bzlmod/docs.md.golden
@@ -7,6 +7,8 @@ A simple macro used to test stardoc.
 ## write_host_constraints
 
 <pre>
+load("@//:def.bzl", "write_host_constraints")
+
 write_host_constraints(<a href="#write_host_constraints-name">name</a>)
 </pre>
 

--- a/test/testdata/angle_bracket_test/golden.md
+++ b/test/testdata/angle_bracket_test/golden.md
@@ -18,6 +18,7 @@ Angle brackets are also preserved in inline code blocks (`#include <vector>`).
 
 <pre>
 load("@stardoc//test:testdata/angle_bracket_test/input.bzl", "my_anglebrac")
+
 my_anglebrac(<a href="#my_anglebrac-name">name</a>, <a href="#my_anglebrac-also_useless">also_useless</a>, <a href="#my_anglebrac-useless">useless</a>)
 </pre>
 
@@ -39,6 +40,7 @@ Rule with \<brackets>
 
 <pre>
 load("@stardoc//test:testdata/angle_bracket_test/input.bzl", "bracketuse")
+
 bracketuse(<a href="#bracketuse-foo">foo</a>, <a href="#bracketuse-bar">bar</a>, <a href="#bracketuse-baz">baz</a>)
 </pre>
 
@@ -60,6 +62,7 @@ Information with \<brackets>
 
 <pre>
 load("@stardoc//test:testdata/angle_bracket_test/input.bzl", "bracket_function")
+
 bracket_function(<a href="#bracket_function-param">param</a>, <a href="#bracket_function-md_string">md_string</a>)
 </pre>
 
@@ -98,8 +101,7 @@ deprecated for \<reasons> as well as `<reasons>`.
 
 <pre>
 load("@stardoc//test:testdata/angle_bracket_test/input.bzl", "bracket_aspect")
-# or on the command line:
-# --aspects=@stardoc//test:testdata/angle_bracket_test/input.bzl%bracket_aspect
+
 bracket_aspect(<a href="#bracket_aspect-name">name</a>, <a href="#bracket_aspect-brackets">brackets</a>)
 </pre>
 

--- a/test/testdata/angle_bracket_test/golden.md
+++ b/test/testdata/angle_bracket_test/golden.md
@@ -17,6 +17,7 @@ Angle brackets are also preserved in inline code blocks (`#include <vector>`).
 ## my_anglebrac
 
 <pre>
+load("@stardoc//test:testdata/angle_bracket_test/input.bzl", "my_anglebrac")
 my_anglebrac(<a href="#my_anglebrac-name">name</a>, <a href="#my_anglebrac-also_useless">also_useless</a>, <a href="#my_anglebrac-useless">useless</a>)
 </pre>
 
@@ -37,6 +38,7 @@ Rule with \<brackets>
 ## bracketuse
 
 <pre>
+load("@stardoc//test:testdata/angle_bracket_test/input.bzl", "bracketuse")
 bracketuse(<a href="#bracketuse-foo">foo</a>, <a href="#bracketuse-bar">bar</a>, <a href="#bracketuse-baz">baz</a>)
 </pre>
 
@@ -57,6 +59,7 @@ Information with \<brackets>
 ## bracket_function
 
 <pre>
+load("@stardoc//test:testdata/angle_bracket_test/input.bzl", "bracket_function")
 bracket_function(<a href="#bracket_function-param">param</a>, <a href="#bracket_function-md_string">md_string</a>)
 </pre>
 
@@ -94,6 +97,9 @@ deprecated for \<reasons> as well as `<reasons>`.
 ## bracket_aspect
 
 <pre>
+load("@stardoc//test:testdata/angle_bracket_test/input.bzl", "bracket_aspect")
+# or on the command line:
+# --aspects=@stardoc//test:testdata/angle_bracket_test/input.bzl%bracket_aspect
 bracket_aspect(<a href="#bracket_aspect-name">name</a>, <a href="#bracket_aspect-brackets">brackets</a>)
 </pre>
 

--- a/test/testdata/apple_basic_test/golden.md
+++ b/test/testdata/apple_basic_test/golden.md
@@ -8,6 +8,7 @@
 
 <pre>
 load("@stardoc//test:testdata/apple_basic_test/input.bzl", "apple_related_rule")
+
 apple_related_rule(<a href="#apple_related_rule-name">name</a>, <a href="#apple_related_rule-first">first</a>, <a href="#apple_related_rule-fourth">fourth</a>, <a href="#apple_related_rule-second">second</a>, <a href="#apple_related_rule-third">third</a>)
 </pre>
 

--- a/test/testdata/apple_basic_test/golden.md
+++ b/test/testdata/apple_basic_test/golden.md
@@ -7,6 +7,7 @@
 ## apple_related_rule
 
 <pre>
+load("@stardoc//test:testdata/apple_basic_test/input.bzl", "apple_related_rule")
 apple_related_rule(<a href="#apple_related_rule-name">name</a>, <a href="#apple_related_rule-first">first</a>, <a href="#apple_related_rule-fourth">fourth</a>, <a href="#apple_related_rule-second">second</a>, <a href="#apple_related_rule-third">third</a>)
 </pre>
 

--- a/test/testdata/aspect_test/golden.md
+++ b/test/testdata/aspect_test/golden.md
@@ -8,6 +8,7 @@ The input file for the aspect test
 
 <pre>
 load("@stardoc//test:testdata/aspect_test/input.bzl", "my_aspect_impl")
+
 my_aspect_impl(<a href="#my_aspect_impl-ctx">ctx</a>)
 </pre>
 
@@ -27,8 +28,7 @@ my_aspect_impl(<a href="#my_aspect_impl-ctx">ctx</a>)
 
 <pre>
 load("@stardoc//test:testdata/aspect_test/input.bzl", "my_aspect")
-# or on the command line:
-# --aspects=@stardoc//test:testdata/aspect_test/input.bzl%my_aspect
+
 my_aspect(<a href="#my_aspect-name">name</a>, <a href="#my_aspect-first">first</a>, <a href="#my_aspect-second">second</a>)
 </pre>
 
@@ -61,6 +61,7 @@ It does stuff.
 
 <pre>
 load("@stardoc//test:testdata/aspect_test/input.bzl", "namespace")
+
 namespace.namespaced_aspect(<a href="#namespace.namespaced_aspect-name">name</a>, <a href="#namespace.namespaced_aspect-third">third</a>)
 </pre>
 
@@ -85,8 +86,7 @@ This is another aspect.
 
 <pre>
 load("@stardoc//test:testdata/aspect_test/input.bzl", "other_aspect")
-# or on the command line:
-# --aspects=@stardoc//test:testdata/aspect_test/input.bzl%other_aspect
+
 other_aspect(<a href="#other_aspect-name">name</a>, <a href="#other_aspect-third">third</a>)
 </pre>
 

--- a/test/testdata/aspect_test/golden.md
+++ b/test/testdata/aspect_test/golden.md
@@ -7,6 +7,7 @@ The input file for the aspect test
 ## my_aspect_impl
 
 <pre>
+load("@stardoc//test:testdata/aspect_test/input.bzl", "my_aspect_impl")
 my_aspect_impl(<a href="#my_aspect_impl-ctx">ctx</a>)
 </pre>
 
@@ -25,6 +26,9 @@ my_aspect_impl(<a href="#my_aspect_impl-ctx">ctx</a>)
 ## my_aspect
 
 <pre>
+load("@stardoc//test:testdata/aspect_test/input.bzl", "my_aspect")
+# or on the command line:
+# --aspects=@stardoc//test:testdata/aspect_test/input.bzl%my_aspect
 my_aspect(<a href="#my_aspect-name">name</a>, <a href="#my_aspect-first">first</a>, <a href="#my_aspect-second">second</a>)
 </pre>
 
@@ -51,11 +55,38 @@ It does stuff.
 | <a id="my_aspect-second"></a>second |  -   | String | required |  |
 
 
+<a id="namespace.namespaced_aspect"></a>
+
+## namespace.namespaced_aspect
+
+<pre>
+load("@stardoc//test:testdata/aspect_test/input.bzl", "namespace")
+namespace.namespaced_aspect(<a href="#namespace.namespaced_aspect-name">name</a>, <a href="#namespace.namespaced_aspect-third">third</a>)
+</pre>
+
+This is another aspect.
+
+**ASPECT ATTRIBUTES**
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="namespace.namespaced_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="namespace.namespaced_aspect-third"></a>third |  -   | Integer | required |  |
+
+
 <a id="other_aspect"></a>
 
 ## other_aspect
 
 <pre>
+load("@stardoc//test:testdata/aspect_test/input.bzl", "other_aspect")
+# or on the command line:
+# --aspects=@stardoc//test:testdata/aspect_test/input.bzl%other_aspect
 other_aspect(<a href="#other_aspect-name">name</a>, <a href="#other_aspect-third">third</a>)
 </pre>
 

--- a/test/testdata/aspect_test/input.bzl
+++ b/test/testdata/aspect_test/input.bzl
@@ -28,3 +28,7 @@ other_aspect = aspect(
         "third": attr.int(mandatory = True),
     },
 )
+
+namespace = struct(
+    namespaced_aspect = other_aspect,
+)

--- a/test/testdata/attribute_defaults_test/golden.md
+++ b/test/testdata/attribute_defaults_test/golden.md
@@ -7,6 +7,7 @@ A golden test to verify attribute default values.
 ## my_rule
 
 <pre>
+load("@stardoc//test:testdata/attribute_defaults_test/input.bzl", "my_rule")
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-a">a</a>, <a href="#my_rule-b">b</a>, <a href="#my_rule-c">c</a>, <a href="#my_rule-d">d</a>, <a href="#my_rule-e">e</a>, <a href="#my_rule-f">f</a>, <a href="#my_rule-g">g</a>, <a href="#my_rule-h">h</a>, <a href="#my_rule-i">i</a>, <a href="#my_rule-j">j</a>, <a href="#my_rule-k">k</a>, <a href="#my_rule-l">l</a>, <a href="#my_rule-m">m</a>, <a href="#my_rule-n">n</a>, <a href="#my_rule-o">o</a>, <a href="#my_rule-p">p</a>, <a href="#my_rule-q">q</a>, <a href="#my_rule-r">r</a>, <a href="#my_rule-s">s</a>, <a href="#my_rule-t">t</a>, <a href="#my_rule-u">u</a>, <a href="#my_rule-v">v</a>, <a href="#my_rule-w">w</a>)
 </pre>
 
@@ -48,6 +49,9 @@ This is my rule. It does stuff.
 ## my_aspect
 
 <pre>
+load("@stardoc//test:testdata/attribute_defaults_test/input.bzl", "my_aspect")
+# or on the command line:
+# --aspects=@stardoc//test:testdata/attribute_defaults_test/input.bzl%my_aspect
 my_aspect(<a href="#my_aspect-name">name</a>, <a href="#my_aspect-y">y</a>, <a href="#my_aspect-z">z</a>)
 </pre>
 

--- a/test/testdata/attribute_defaults_test/golden.md
+++ b/test/testdata/attribute_defaults_test/golden.md
@@ -8,6 +8,7 @@ A golden test to verify attribute default values.
 
 <pre>
 load("@stardoc//test:testdata/attribute_defaults_test/input.bzl", "my_rule")
+
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-a">a</a>, <a href="#my_rule-b">b</a>, <a href="#my_rule-c">c</a>, <a href="#my_rule-d">d</a>, <a href="#my_rule-e">e</a>, <a href="#my_rule-f">f</a>, <a href="#my_rule-g">g</a>, <a href="#my_rule-h">h</a>, <a href="#my_rule-i">i</a>, <a href="#my_rule-j">j</a>, <a href="#my_rule-k">k</a>, <a href="#my_rule-l">l</a>, <a href="#my_rule-m">m</a>, <a href="#my_rule-n">n</a>, <a href="#my_rule-o">o</a>, <a href="#my_rule-p">p</a>, <a href="#my_rule-q">q</a>, <a href="#my_rule-r">r</a>, <a href="#my_rule-s">s</a>, <a href="#my_rule-t">t</a>, <a href="#my_rule-u">u</a>, <a href="#my_rule-v">v</a>, <a href="#my_rule-w">w</a>)
 </pre>
 
@@ -50,8 +51,7 @@ This is my rule. It does stuff.
 
 <pre>
 load("@stardoc//test:testdata/attribute_defaults_test/input.bzl", "my_aspect")
-# or on the command line:
-# --aspects=@stardoc//test:testdata/attribute_defaults_test/input.bzl%my_aspect
+
 my_aspect(<a href="#my_aspect-name">name</a>, <a href="#my_aspect-y">y</a>, <a href="#my_aspect-z">z</a>)
 </pre>
 

--- a/test/testdata/attribute_types_test/golden.md
+++ b/test/testdata/attribute_types_test/golden.md
@@ -8,6 +8,7 @@
 
 <pre>
 load("@stardoc//test:testdata/attribute_types_test/input.bzl", "my_rule")
+
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-a">a</a>, <a href="#my_rule-b">b</a>, <a href="#my_rule-c">c</a>, <a href="#my_rule-d">d</a>, <a href="#my_rule-e">e</a>, <a href="#my_rule-f">f</a>, <a href="#my_rule-g">g</a>, <a href="#my_rule-h">h</a>, <a href="#my_rule-i">i</a>, <a href="#my_rule-j">j</a>, <a href="#my_rule-k">k</a>, <a href="#my_rule-l">l</a>)
 </pre>
 

--- a/test/testdata/attribute_types_test/golden.md
+++ b/test/testdata/attribute_types_test/golden.md
@@ -7,6 +7,7 @@
 ## my_rule
 
 <pre>
+load("@stardoc//test:testdata/attribute_types_test/input.bzl", "my_rule")
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-a">a</a>, <a href="#my_rule-b">b</a>, <a href="#my_rule-c">c</a>, <a href="#my_rule-d">d</a>, <a href="#my_rule-e">e</a>, <a href="#my_rule-f">f</a>, <a href="#my_rule-g">g</a>, <a href="#my_rule-h">h</a>, <a href="#my_rule-i">i</a>, <a href="#my_rule-j">j</a>, <a href="#my_rule-k">k</a>, <a href="#my_rule-l">l</a>)
 </pre>
 

--- a/test/testdata/cc_api_test/golden.md
+++ b/test/testdata/cc_api_test/golden.md
@@ -7,6 +7,7 @@ Input file for C++ api test
 ## cpp_related_rule
 
 <pre>
+load("@stardoc//test:testdata/cc_api_test/input.bzl", "cpp_related_rule")
 cpp_related_rule(<a href="#cpp_related_rule-name">name</a>, <a href="#cpp_related_rule-first">first</a>, <a href="#cpp_related_rule-fourth">fourth</a>, <a href="#cpp_related_rule-second">second</a>, <a href="#cpp_related_rule-third">third</a>)
 </pre>
 
@@ -29,6 +30,7 @@ This rule does C++-related things.
 ## exercise_the_api
 
 <pre>
+load("@stardoc//test:testdata/cc_api_test/input.bzl", "exercise_the_api")
 exercise_the_api()
 </pre>
 
@@ -41,6 +43,7 @@ exercise_the_api()
 ## my_rule_impl
 
 <pre>
+load("@stardoc//test:testdata/cc_api_test/input.bzl", "my_rule_impl")
 my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 </pre>
 

--- a/test/testdata/cc_api_test/golden.md
+++ b/test/testdata/cc_api_test/golden.md
@@ -8,6 +8,7 @@ Input file for C++ api test
 
 <pre>
 load("@stardoc//test:testdata/cc_api_test/input.bzl", "cpp_related_rule")
+
 cpp_related_rule(<a href="#cpp_related_rule-name">name</a>, <a href="#cpp_related_rule-first">first</a>, <a href="#cpp_related_rule-fourth">fourth</a>, <a href="#cpp_related_rule-second">second</a>, <a href="#cpp_related_rule-third">third</a>)
 </pre>
 
@@ -31,6 +32,7 @@ This rule does C++-related things.
 
 <pre>
 load("@stardoc//test:testdata/cc_api_test/input.bzl", "exercise_the_api")
+
 exercise_the_api()
 </pre>
 
@@ -44,6 +46,7 @@ exercise_the_api()
 
 <pre>
 load("@stardoc//test:testdata/cc_api_test/input.bzl", "my_rule_impl")
+
 my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 </pre>
 

--- a/test/testdata/config_apis_test/golden.md
+++ b/test/testdata/config_apis_test/golden.md
@@ -7,6 +7,7 @@
 ## int_setting
 
 <pre>
+load("@stardoc//test:testdata/config_apis_test/input.bzl", "int_setting")
 int_setting(<a href="#int_setting-name">name</a>)
 </pre>
 
@@ -25,6 +26,7 @@ An integer flag.
 ## string_flag
 
 <pre>
+load("@stardoc//test:testdata/config_apis_test/input.bzl", "string_flag")
 string_flag(<a href="#string_flag-name">name</a>)
 </pre>
 
@@ -43,6 +45,7 @@ A string flag.
 ## exercise_the_api
 
 <pre>
+load("@stardoc//test:testdata/config_apis_test/input.bzl", "exercise_the_api")
 exercise_the_api()
 </pre>
 
@@ -55,6 +58,7 @@ exercise_the_api()
 ## transition_func
 
 <pre>
+load("@stardoc//test:testdata/config_apis_test/input.bzl", "transition_func")
 transition_func(<a href="#transition_func-settings">settings</a>)
 </pre>
 

--- a/test/testdata/config_apis_test/golden.md
+++ b/test/testdata/config_apis_test/golden.md
@@ -8,6 +8,7 @@
 
 <pre>
 load("@stardoc//test:testdata/config_apis_test/input.bzl", "int_setting")
+
 int_setting(<a href="#int_setting-name">name</a>)
 </pre>
 
@@ -27,6 +28,7 @@ An integer flag.
 
 <pre>
 load("@stardoc//test:testdata/config_apis_test/input.bzl", "string_flag")
+
 string_flag(<a href="#string_flag-name">name</a>)
 </pre>
 
@@ -46,6 +48,7 @@ A string flag.
 
 <pre>
 load("@stardoc//test:testdata/config_apis_test/input.bzl", "exercise_the_api")
+
 exercise_the_api()
 </pre>
 
@@ -59,6 +62,7 @@ exercise_the_api()
 
 <pre>
 load("@stardoc//test:testdata/config_apis_test/input.bzl", "transition_func")
+
 transition_func(<a href="#transition_func-settings">settings</a>)
 </pre>
 

--- a/test/testdata/cpp_basic_test/golden.md
+++ b/test/testdata/cpp_basic_test/golden.md
@@ -8,6 +8,7 @@
 
 <pre>
 load("@stardoc//test:testdata/cpp_basic_test/input.bzl", "cpp_related_rule")
+
 cpp_related_rule(<a href="#cpp_related_rule-name">name</a>, <a href="#cpp_related_rule-first">first</a>, <a href="#cpp_related_rule-fourth">fourth</a>, <a href="#cpp_related_rule-second">second</a>, <a href="#cpp_related_rule-third">third</a>)
 </pre>
 

--- a/test/testdata/cpp_basic_test/golden.md
+++ b/test/testdata/cpp_basic_test/golden.md
@@ -7,6 +7,7 @@
 ## cpp_related_rule
 
 <pre>
+load("@stardoc//test:testdata/cpp_basic_test/input.bzl", "cpp_related_rule")
 cpp_related_rule(<a href="#cpp_related_rule-name">name</a>, <a href="#cpp_related_rule-first">first</a>, <a href="#cpp_related_rule-fourth">fourth</a>, <a href="#cpp_related_rule-second">second</a>, <a href="#cpp_related_rule-third">third</a>)
 </pre>
 

--- a/test/testdata/filter_rules_test/golden.md
+++ b/test/testdata/filter_rules_test/golden.md
@@ -7,6 +7,7 @@
 ## allowlisted_dep_rule
 
 <pre>
+load("@stardoc//test:testdata/filter_rules_test/input.bzl", "allowlisted_dep_rule")
 allowlisted_dep_rule(<a href="#allowlisted_dep_rule-name">name</a>, <a href="#allowlisted_dep_rule-first">first</a>, <a href="#allowlisted_dep_rule-second">second</a>)
 </pre>
 
@@ -27,6 +28,7 @@ This is the dep rule. It does stuff.
 ## my_rule
 
 <pre>
+load("@stardoc//test:testdata/filter_rules_test/input.bzl", "my_rule")
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-second">second</a>)
 </pre>
 

--- a/test/testdata/filter_rules_test/golden.md
+++ b/test/testdata/filter_rules_test/golden.md
@@ -8,6 +8,7 @@
 
 <pre>
 load("@stardoc//test:testdata/filter_rules_test/input.bzl", "allowlisted_dep_rule")
+
 allowlisted_dep_rule(<a href="#allowlisted_dep_rule-name">name</a>, <a href="#allowlisted_dep_rule-first">first</a>, <a href="#allowlisted_dep_rule-second">second</a>)
 </pre>
 
@@ -29,6 +30,7 @@ This is the dep rule. It does stuff.
 
 <pre>
 load("@stardoc//test:testdata/filter_rules_test/input.bzl", "my_rule")
+
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-second">second</a>)
 </pre>
 

--- a/test/testdata/function_basic_test/golden.md
+++ b/test/testdata/function_basic_test/golden.md
@@ -7,6 +7,7 @@ A test that verifies basic user function documentation.
 ## check_sources
 
 <pre>
+load("@stardoc//test:testdata/function_basic_test/input.bzl", "check_sources")
 check_sources(<a href="#check_sources-name">name</a>, <a href="#check_sources-required_param">required_param</a>, <a href="#check_sources-bool_param">bool_param</a>, <a href="#check_sources-srcs">srcs</a>, <a href="#check_sources-string_param">string_param</a>, <a href="#check_sources-int_param">int_param</a>, <a href="#check_sources-dict_param">dict_param</a>,
               <a href="#check_sources-struct_param">struct_param</a>)
 </pre>
@@ -37,6 +38,7 @@ Use `bazel build` to run the check.
 ## deprecated_do_not_use
 
 <pre>
+load("@stardoc//test:testdata/function_basic_test/input.bzl", "deprecated_do_not_use")
 deprecated_do_not_use()
 </pre>
 
@@ -53,6 +55,7 @@ Use literally anything but this function.
 ## param_doc_multiline
 
 <pre>
+load("@stardoc//test:testdata/function_basic_test/input.bzl", "param_doc_multiline")
 param_doc_multiline(<a href="#param_doc_multiline-complex">complex</a>)
 </pre>
 
@@ -71,6 +74,7 @@ Has a complex parameter.
 ## returns_a_thing
 
 <pre>
+load("@stardoc//test:testdata/function_basic_test/input.bzl", "returns_a_thing")
 returns_a_thing(<a href="#returns_a_thing-name">name</a>)
 </pre>
 
@@ -93,6 +97,7 @@ A suffixed version of the name.
 ## undocumented_function
 
 <pre>
+load("@stardoc//test:testdata/function_basic_test/input.bzl", "undocumented_function")
 undocumented_function(<a href="#undocumented_function-a">a</a>, <a href="#undocumented_function-b">b</a>, <a href="#undocumented_function-c">c</a>)
 </pre>
 

--- a/test/testdata/function_basic_test/golden.md
+++ b/test/testdata/function_basic_test/golden.md
@@ -8,6 +8,7 @@ A test that verifies basic user function documentation.
 
 <pre>
 load("@stardoc//test:testdata/function_basic_test/input.bzl", "check_sources")
+
 check_sources(<a href="#check_sources-name">name</a>, <a href="#check_sources-required_param">required_param</a>, <a href="#check_sources-bool_param">bool_param</a>, <a href="#check_sources-srcs">srcs</a>, <a href="#check_sources-string_param">string_param</a>, <a href="#check_sources-int_param">int_param</a>, <a href="#check_sources-dict_param">dict_param</a>,
               <a href="#check_sources-struct_param">struct_param</a>)
 </pre>
@@ -39,6 +40,7 @@ Use `bazel build` to run the check.
 
 <pre>
 load("@stardoc//test:testdata/function_basic_test/input.bzl", "deprecated_do_not_use")
+
 deprecated_do_not_use()
 </pre>
 
@@ -56,6 +58,7 @@ Use literally anything but this function.
 
 <pre>
 load("@stardoc//test:testdata/function_basic_test/input.bzl", "param_doc_multiline")
+
 param_doc_multiline(<a href="#param_doc_multiline-complex">complex</a>)
 </pre>
 
@@ -75,6 +78,7 @@ Has a complex parameter.
 
 <pre>
 load("@stardoc//test:testdata/function_basic_test/input.bzl", "returns_a_thing")
+
 returns_a_thing(<a href="#returns_a_thing-name">name</a>)
 </pre>
 
@@ -98,6 +102,7 @@ A suffixed version of the name.
 
 <pre>
 load("@stardoc//test:testdata/function_basic_test/input.bzl", "undocumented_function")
+
 undocumented_function(<a href="#undocumented_function-a">a</a>, <a href="#undocumented_function-b">b</a>, <a href="#undocumented_function-c">c</a>)
 </pre>
 

--- a/test/testdata/function_wrap_multiple_lines_test/golden.md
+++ b/test/testdata/function_wrap_multiple_lines_test/golden.md
@@ -8,6 +8,7 @@ Rules for ANTLR 3.
 
 <pre>
 load("@stardoc//test:testdata/function_wrap_multiple_lines_test/input.bzl", "antlr")
+
 antlr(<a href="#antlr-name">name</a>, <a href="#antlr-deps">deps</a>, <a href="#antlr-srcs">srcs</a>, <a href="#antlr-Xconversiontimeout">Xconversiontimeout</a>, <a href="#antlr-Xdbgconversion">Xdbgconversion</a>, <a href="#antlr-Xdbgst">Xdbgst</a>, <a href="#antlr-Xdfa">Xdfa</a>, <a href="#antlr-Xdfaverbose">Xdfaverbose</a>, <a href="#antlr-Xgrtree">Xgrtree</a>, <a href="#antlr-Xm">Xm</a>,
       <a href="#antlr-Xmaxdfaedges">Xmaxdfaedges</a>, <a href="#antlr-Xmaxinlinedfastates">Xmaxinlinedfastates</a>, <a href="#antlr-Xminswitchalts">Xminswitchalts</a>, <a href="#antlr-Xmultithreaded">Xmultithreaded</a>, <a href="#antlr-Xnfastates">Xnfastates</a>, <a href="#antlr-Xnocollapse">Xnocollapse</a>,
       <a href="#antlr-Xnomergestopstates">Xnomergestopstates</a>, <a href="#antlr-Xnoprune">Xnoprune</a>, <a href="#antlr-XsaveLexer">XsaveLexer</a>, <a href="#antlr-Xwatchconversion">Xwatchconversion</a>, <a href="#antlr-debug">debug</a>, <a href="#antlr-depend">depend</a>, <a href="#antlr-dfa">dfa</a>, <a href="#antlr-dump">dump</a>, <a href="#antlr-imports">imports</a>,

--- a/test/testdata/function_wrap_multiple_lines_test/golden.md
+++ b/test/testdata/function_wrap_multiple_lines_test/golden.md
@@ -7,6 +7,7 @@ Rules for ANTLR 3.
 ## antlr
 
 <pre>
+load("@stardoc//test:testdata/function_wrap_multiple_lines_test/input.bzl", "antlr")
 antlr(<a href="#antlr-name">name</a>, <a href="#antlr-deps">deps</a>, <a href="#antlr-srcs">srcs</a>, <a href="#antlr-Xconversiontimeout">Xconversiontimeout</a>, <a href="#antlr-Xdbgconversion">Xdbgconversion</a>, <a href="#antlr-Xdbgst">Xdbgst</a>, <a href="#antlr-Xdfa">Xdfa</a>, <a href="#antlr-Xdfaverbose">Xdfaverbose</a>, <a href="#antlr-Xgrtree">Xgrtree</a>, <a href="#antlr-Xm">Xm</a>,
       <a href="#antlr-Xmaxdfaedges">Xmaxdfaedges</a>, <a href="#antlr-Xmaxinlinedfastates">Xmaxinlinedfastates</a>, <a href="#antlr-Xminswitchalts">Xminswitchalts</a>, <a href="#antlr-Xmultithreaded">Xmultithreaded</a>, <a href="#antlr-Xnfastates">Xnfastates</a>, <a href="#antlr-Xnocollapse">Xnocollapse</a>,
       <a href="#antlr-Xnomergestopstates">Xnomergestopstates</a>, <a href="#antlr-Xnoprune">Xnoprune</a>, <a href="#antlr-XsaveLexer">XsaveLexer</a>, <a href="#antlr-Xwatchconversion">Xwatchconversion</a>, <a href="#antlr-debug">debug</a>, <a href="#antlr-depend">depend</a>, <a href="#antlr-dfa">dfa</a>, <a href="#antlr-dump">dump</a>, <a href="#antlr-imports">imports</a>,

--- a/test/testdata/html_tables_template_test/golden.md
+++ b/test/testdata/html_tables_template_test/golden.md
@@ -7,6 +7,7 @@ Input file for markdown template test
 ## example_rule
 
 <pre>
+load("@stardoc//test:testdata/html_tables_template_test/input.bzl", "example_rule")
 example_rule(<a href="#example_rule-name">name</a>, <a href="#example_rule-first">first</a>, <a href="#example_rule-second">second</a>)
 </pre>
 
@@ -63,6 +64,7 @@ String; optional
 ## ExampleProviderInfo
 
 <pre>
+load("@stardoc//test:testdata/html_tables_template_test/input.bzl", "ExampleProviderInfo")
 ExampleProviderInfo(<a href="#ExampleProviderInfo-foo">foo</a>, <a href="#ExampleProviderInfo-bar">bar</a>, <a href="#ExampleProviderInfo-baz">baz</a>)
 </pre>
 
@@ -115,6 +117,7 @@ A string representing baz
 ## example_function
 
 <pre>
+load("@stardoc//test:testdata/html_tables_template_test/input.bzl", "example_function")
 example_function(<a href="#example_function-foo">foo</a>, <a href="#example_function-bar">bar</a>)
 </pre>
 
@@ -164,6 +167,9 @@ This parameter does bar related things.
 ## example_aspect
 
 <pre>
+load("@stardoc//test:testdata/html_tables_template_test/input.bzl", "example_aspect")
+# or on the command line:
+# --aspects=@stardoc//test:testdata/html_tables_template_test/input.bzl%example_aspect
 example_aspect(<a href="#example_aspect-name">name</a>, <a href="#example_aspect-first">first</a>, <a href="#example_aspect-second">second</a>)
 </pre>
 

--- a/test/testdata/html_tables_template_test/golden.md
+++ b/test/testdata/html_tables_template_test/golden.md
@@ -65,11 +65,8 @@ String; optional
 ## ExampleProviderInfo
 
 <pre>
-<<<<<<< HEAD
 load("@stardoc//test:testdata/html_tables_template_test/input.bzl", "ExampleProviderInfo")
 
-=======
->>>>>>> origin/master
 ExampleProviderInfo(<a href="#ExampleProviderInfo-foo">foo</a>, <a href="#ExampleProviderInfo-bar">bar</a>, <a href="#ExampleProviderInfo-baz">baz</a>)
 </pre>
 

--- a/test/testdata/html_tables_template_test/golden.md
+++ b/test/testdata/html_tables_template_test/golden.md
@@ -8,6 +8,7 @@ Input file for markdown template test
 
 <pre>
 load("@stardoc//test:testdata/html_tables_template_test/input.bzl", "example_rule")
+
 example_rule(<a href="#example_rule-name">name</a>, <a href="#example_rule-first">first</a>, <a href="#example_rule-second">second</a>)
 </pre>
 
@@ -65,6 +66,7 @@ String; optional
 
 <pre>
 load("@stardoc//test:testdata/html_tables_template_test/input.bzl", "ExampleProviderInfo")
+
 ExampleProviderInfo(<a href="#ExampleProviderInfo-foo">foo</a>, <a href="#ExampleProviderInfo-bar">bar</a>, <a href="#ExampleProviderInfo-baz">baz</a>)
 </pre>
 
@@ -118,6 +120,7 @@ A string representing baz
 
 <pre>
 load("@stardoc//test:testdata/html_tables_template_test/input.bzl", "example_function")
+
 example_function(<a href="#example_function-foo">foo</a>, <a href="#example_function-bar">bar</a>)
 </pre>
 
@@ -168,8 +171,7 @@ This parameter does bar related things.
 
 <pre>
 load("@stardoc//test:testdata/html_tables_template_test/input.bzl", "example_aspect")
-# or on the command line:
-# --aspects=@stardoc//test:testdata/html_tables_template_test/input.bzl%example_aspect
+
 example_aspect(<a href="#example_aspect-name">name</a>, <a href="#example_aspect-first">first</a>, <a href="#example_aspect-second">second</a>)
 </pre>
 

--- a/test/testdata/input_template_test/golden.md
+++ b/test/testdata/input_template_test/golden.md
@@ -7,6 +7,7 @@ Module Docstring: "Input file for input template test"
 ## my_example
 
 <pre>
+load("@stardoc//test:testdata/input_template_test/input.bzl", "my_example")
 my_example(<a href="#my_example-name">name</a>, <a href="#my_example-useless">useless</a>)
 </pre>
 
@@ -38,6 +39,7 @@ Small example of rule using chosen template.
 ## example
 
 <pre>
+load("@stardoc//test:testdata/input_template_test/input.bzl", "example")
 example(<a href="#example-foo">foo</a>, <a href="#example-bar">bar</a>, <a href="#example-baz">baz</a>)
 </pre>
 
@@ -66,6 +68,7 @@ Stores information about an example in chosen template.
 ## my_aspect_impl
 
 <pre>
+load("@stardoc//test:testdata/input_template_test/input.bzl", "my_aspect_impl")
 my_aspect_impl(<a href="#my_aspect_impl-ctx">ctx</a>)
 </pre>
 
@@ -84,6 +87,7 @@ my_aspect_impl(<a href="#my_aspect_impl-ctx">ctx</a>)
 ## template_function
 
 <pre>
+load("@stardoc//test:testdata/input_template_test/input.bzl", "template_function")
 template_function(<a href="#template_function-foo">foo</a>)
 </pre>
 
@@ -109,6 +113,9 @@ Use `bazel build` to run the check.
 ## my_aspect
 
 <pre>
+load("@stardoc//test:testdata/input_template_test/input.bzl", "my_aspect")
+# or on the command line:
+# --aspects=@stardoc//test:testdata/input_template_test/input.bzl%my_aspect
 my_aspect(<a href="#my_aspect-name">name</a>, <a href="#my_aspect-first">first</a>)
 </pre>
 

--- a/test/testdata/input_template_test/golden.md
+++ b/test/testdata/input_template_test/golden.md
@@ -7,7 +7,6 @@ Module Docstring: "Input file for input template test"
 ## my_example
 
 <pre>
-load("@stardoc//test:testdata/input_template_test/input.bzl", "my_example")
 my_example(<a href="#my_example-name">name</a>, <a href="#my_example-useless">useless</a>)
 </pre>
 
@@ -39,7 +38,6 @@ Small example of rule using chosen template.
 ## example
 
 <pre>
-load("@stardoc//test:testdata/input_template_test/input.bzl", "example")
 example(<a href="#example-foo">foo</a>, <a href="#example-bar">bar</a>, <a href="#example-baz">baz</a>)
 </pre>
 
@@ -68,7 +66,6 @@ Stores information about an example in chosen template.
 ## my_aspect_impl
 
 <pre>
-load("@stardoc//test:testdata/input_template_test/input.bzl", "my_aspect_impl")
 my_aspect_impl(<a href="#my_aspect_impl-ctx">ctx</a>)
 </pre>
 
@@ -87,7 +84,6 @@ my_aspect_impl(<a href="#my_aspect_impl-ctx">ctx</a>)
 ## template_function
 
 <pre>
-load("@stardoc//test:testdata/input_template_test/input.bzl", "template_function")
 template_function(<a href="#template_function-foo">foo</a>)
 </pre>
 
@@ -113,9 +109,6 @@ Use `bazel build` to run the check.
 ## my_aspect
 
 <pre>
-load("@stardoc//test:testdata/input_template_test/input.bzl", "my_aspect")
-# or on the command line:
-# --aspects=@stardoc//test:testdata/input_template_test/input.bzl%my_aspect
 my_aspect(<a href="#my_aspect-name">name</a>, <a href="#my_aspect-first">first</a>)
 </pre>
 

--- a/test/testdata/java_basic_test/golden.md
+++ b/test/testdata/java_basic_test/golden.md
@@ -7,6 +7,7 @@
 ## java_related_rule
 
 <pre>
+load("@stardoc//test:testdata/java_basic_test/input.bzl", "java_related_rule")
 java_related_rule(<a href="#java_related_rule-name">name</a>, <a href="#java_related_rule-first">first</a>, <a href="#java_related_rule-fourth">fourth</a>, <a href="#java_related_rule-second">second</a>, <a href="#java_related_rule-third">third</a>)
 </pre>
 

--- a/test/testdata/java_basic_test/golden.md
+++ b/test/testdata/java_basic_test/golden.md
@@ -8,6 +8,7 @@
 
 <pre>
 load("@stardoc//test:testdata/java_basic_test/input.bzl", "java_related_rule")
+
 java_related_rule(<a href="#java_related_rule-name">name</a>, <a href="#java_related_rule-first">first</a>, <a href="#java_related_rule-fourth">fourth</a>, <a href="#java_related_rule-second">second</a>, <a href="#java_related_rule-third">third</a>)
 </pre>
 

--- a/test/testdata/local_repository_test/golden.md
+++ b/test/testdata/local_repository_test/golden.md
@@ -7,6 +7,7 @@ A test that verifies documenting functions in an input file under a local_reposi
 ## min
 
 <pre>
+load("@local_repository_test//:input.bzl", "min")
 min(<a href="#min-integers">integers</a>)
 </pre>
 

--- a/test/testdata/local_repository_test/golden.md
+++ b/test/testdata/local_repository_test/golden.md
@@ -8,6 +8,7 @@ A test that verifies documenting functions in an input file under a local_reposi
 
 <pre>
 load("@local_repository_test//:input.bzl", "min")
+
 min(<a href="#min-integers">integers</a>)
 </pre>
 

--- a/test/testdata/macro_kwargs_test/golden.md
+++ b/test/testdata/macro_kwargs_test/golden.md
@@ -8,6 +8,7 @@ Tests for functions which use *args or **kwargs
 
 <pre>
 load("@stardoc//test:testdata/macro_kwargs_test/input.bzl", "macro_with_args")
+
 macro_with_args(<a href="#macro_with_args-name">name</a>, <a href="#macro_with_args-args">args</a>)
 </pre>
 
@@ -32,6 +33,7 @@ An empty list.
 
 <pre>
 load("@stardoc//test:testdata/macro_kwargs_test/input.bzl", "macro_with_both")
+
 macro_with_both(<a href="#macro_with_both-name">name</a>, <a href="#macro_with_both-number">number</a>, <a href="#macro_with_both-args">args</a>, <a href="#macro_with_both-kwargs">kwargs</a>)
 </pre>
 
@@ -61,6 +63,7 @@ An empty list.
 
 <pre>
 load("@stardoc//test:testdata/macro_kwargs_test/input.bzl", "macro_with_kwargs")
+
 macro_with_kwargs(<a href="#macro_with_kwargs-name">name</a>, <a href="#macro_with_kwargs-config">config</a>, <a href="#macro_with_kwargs-deps">deps</a>, <a href="#macro_with_kwargs-kwargs">kwargs</a>)
 </pre>
 

--- a/test/testdata/macro_kwargs_test/golden.md
+++ b/test/testdata/macro_kwargs_test/golden.md
@@ -7,6 +7,7 @@ Tests for functions which use *args or **kwargs
 ## macro_with_args
 
 <pre>
+load("@stardoc//test:testdata/macro_kwargs_test/input.bzl", "macro_with_args")
 macro_with_args(<a href="#macro_with_args-name">name</a>, <a href="#macro_with_args-args">args</a>)
 </pre>
 
@@ -30,6 +31,7 @@ An empty list.
 ## macro_with_both
 
 <pre>
+load("@stardoc//test:testdata/macro_kwargs_test/input.bzl", "macro_with_both")
 macro_with_both(<a href="#macro_with_both-name">name</a>, <a href="#macro_with_both-number">number</a>, <a href="#macro_with_both-args">args</a>, <a href="#macro_with_both-kwargs">kwargs</a>)
 </pre>
 
@@ -58,6 +60,7 @@ An empty list.
 ## macro_with_kwargs
 
 <pre>
+load("@stardoc//test:testdata/macro_kwargs_test/input.bzl", "macro_with_kwargs")
 macro_with_kwargs(<a href="#macro_with_kwargs-name">name</a>, <a href="#macro_with_kwargs-config">config</a>, <a href="#macro_with_kwargs-deps">deps</a>, <a href="#macro_with_kwargs-kwargs">kwargs</a>)
 </pre>
 

--- a/test/testdata/misc_apis_test/golden.md
+++ b/test/testdata/misc_apis_test/golden.md
@@ -8,6 +8,7 @@
 
 <pre>
 load("@stardoc//test:testdata/misc_apis_test/input.bzl", "my_rule")
+
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-deps">deps</a>, <a href="#my_rule-src">src</a>, <a href="#my_rule-out">out</a>, <a href="#my_rule-extra_arguments">extra_arguments</a>, <a href="#my_rule-tool">tool</a>)
 </pre>
 
@@ -32,6 +33,7 @@ This rule exercises some of the build API.
 
 <pre>
 load("@stardoc//test:testdata/misc_apis_test/input.bzl", "MyInfo")
+
 MyInfo(<a href="#MyInfo-foo">foo</a>, <a href="#MyInfo-bar">bar</a>)
 </pre>
 
@@ -52,6 +54,7 @@ MyInfo(<a href="#MyInfo-foo">foo</a>, <a href="#MyInfo-bar">bar</a>)
 
 <pre>
 load("@stardoc//test:testdata/misc_apis_test/input.bzl", "exercise_the_api")
+
 exercise_the_api()
 </pre>
 
@@ -65,6 +68,7 @@ exercise_the_api()
 
 <pre>
 load("@stardoc//test:testdata/misc_apis_test/input.bzl", "my_rule_impl")
+
 my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 </pre>
 

--- a/test/testdata/misc_apis_test/golden.md
+++ b/test/testdata/misc_apis_test/golden.md
@@ -7,6 +7,7 @@
 ## my_rule
 
 <pre>
+load("@stardoc//test:testdata/misc_apis_test/input.bzl", "my_rule")
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-deps">deps</a>, <a href="#my_rule-src">src</a>, <a href="#my_rule-out">out</a>, <a href="#my_rule-extra_arguments">extra_arguments</a>, <a href="#my_rule-tool">tool</a>)
 </pre>
 
@@ -30,6 +31,7 @@ This rule exercises some of the build API.
 ## MyInfo
 
 <pre>
+load("@stardoc//test:testdata/misc_apis_test/input.bzl", "MyInfo")
 MyInfo(<a href="#MyInfo-foo">foo</a>, <a href="#MyInfo-bar">bar</a>)
 </pre>
 
@@ -49,6 +51,7 @@ MyInfo(<a href="#MyInfo-foo">foo</a>, <a href="#MyInfo-bar">bar</a>)
 ## exercise_the_api
 
 <pre>
+load("@stardoc//test:testdata/misc_apis_test/input.bzl", "exercise_the_api")
 exercise_the_api()
 </pre>
 
@@ -61,6 +64,7 @@ exercise_the_api()
 ## my_rule_impl
 
 <pre>
+load("@stardoc//test:testdata/misc_apis_test/input.bzl", "my_rule_impl")
 my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 </pre>
 

--- a/test/testdata/multi_level_namespace_test/golden.md
+++ b/test/testdata/multi_level_namespace_test/golden.md
@@ -8,6 +8,7 @@ A test that verifies documenting a multi-leveled namespace of functions.
 
 <pre>
 load("@stardoc//test:testdata/multi_level_namespace_test/input.bzl", "my_namespace")
+
 my_namespace.foo.bar.baz()
 </pre>
 
@@ -21,6 +22,7 @@ This function does nothing.
 
 <pre>
 load("@stardoc//test:testdata/multi_level_namespace_test/input.bzl", "my_namespace")
+
 my_namespace.math.min(<a href="#my_namespace.math.min-integers">integers</a>)
 </pre>
 
@@ -44,6 +46,7 @@ The minimum integer in the given list.
 
 <pre>
 load("@stardoc//test:testdata/multi_level_namespace_test/input.bzl", "my_namespace")
+
 my_namespace.min(<a href="#my_namespace.min-integers">integers</a>)
 </pre>
 
@@ -67,6 +70,7 @@ The minimum integer in the given list.
 
 <pre>
 load("@stardoc//test:testdata/multi_level_namespace_test/input.bzl", "my_namespace")
+
 my_namespace.one.three.does_nothing()
 </pre>
 
@@ -80,6 +84,7 @@ This function does nothing.
 
 <pre>
 load("@stardoc//test:testdata/multi_level_namespace_test/input.bzl", "my_namespace")
+
 my_namespace.one.two.min(<a href="#my_namespace.one.two.min-integers">integers</a>)
 </pre>
 

--- a/test/testdata/multi_level_namespace_test/golden.md
+++ b/test/testdata/multi_level_namespace_test/golden.md
@@ -7,6 +7,7 @@ A test that verifies documenting a multi-leveled namespace of functions.
 ## my_namespace.foo.bar.baz
 
 <pre>
+load("@stardoc//test:testdata/multi_level_namespace_test/input.bzl", "my_namespace")
 my_namespace.foo.bar.baz()
 </pre>
 
@@ -19,6 +20,7 @@ This function does nothing.
 ## my_namespace.math.min
 
 <pre>
+load("@stardoc//test:testdata/multi_level_namespace_test/input.bzl", "my_namespace")
 my_namespace.math.min(<a href="#my_namespace.math.min-integers">integers</a>)
 </pre>
 
@@ -41,6 +43,7 @@ The minimum integer in the given list.
 ## my_namespace.min
 
 <pre>
+load("@stardoc//test:testdata/multi_level_namespace_test/input.bzl", "my_namespace")
 my_namespace.min(<a href="#my_namespace.min-integers">integers</a>)
 </pre>
 
@@ -63,6 +66,7 @@ The minimum integer in the given list.
 ## my_namespace.one.three.does_nothing
 
 <pre>
+load("@stardoc//test:testdata/multi_level_namespace_test/input.bzl", "my_namespace")
 my_namespace.one.three.does_nothing()
 </pre>
 
@@ -75,6 +79,7 @@ This function does nothing.
 ## my_namespace.one.two.min
 
 <pre>
+load("@stardoc//test:testdata/multi_level_namespace_test/input.bzl", "my_namespace")
 my_namespace.one.two.min(<a href="#my_namespace.one.two.min-integers">integers</a>)
 </pre>
 

--- a/test/testdata/multi_level_namespace_test_with_allowlist/golden.md
+++ b/test/testdata/multi_level_namespace_test_with_allowlist/golden.md
@@ -9,6 +9,7 @@ specific symbol in other_namespace to be documented.
 ## my_namespace.math.min
 
 <pre>
+load("@stardoc//test:testdata/multi_level_namespace_test_with_allowlist/input.bzl", "my_namespace")
 my_namespace.math.min(<a href="#my_namespace.math.min-integers">integers</a>)
 </pre>
 
@@ -27,6 +28,7 @@ Returns the minimum of given elements.
 ## my_namespace.min
 
 <pre>
+load("@stardoc//test:testdata/multi_level_namespace_test_with_allowlist/input.bzl", "my_namespace")
 my_namespace.min(<a href="#my_namespace.min-integers">integers</a>)
 </pre>
 
@@ -45,6 +47,7 @@ Returns the minimum of given elements.
 ## other_namespace.foo.nothing
 
 <pre>
+load("@stardoc//test:testdata/multi_level_namespace_test_with_allowlist/input.bzl", "other_namespace")
 other_namespace.foo.nothing()
 </pre>
 

--- a/test/testdata/multi_level_namespace_test_with_allowlist/golden.md
+++ b/test/testdata/multi_level_namespace_test_with_allowlist/golden.md
@@ -10,6 +10,7 @@ specific symbol in other_namespace to be documented.
 
 <pre>
 load("@stardoc//test:testdata/multi_level_namespace_test_with_allowlist/input.bzl", "my_namespace")
+
 my_namespace.math.min(<a href="#my_namespace.math.min-integers">integers</a>)
 </pre>
 
@@ -29,6 +30,7 @@ Returns the minimum of given elements.
 
 <pre>
 load("@stardoc//test:testdata/multi_level_namespace_test_with_allowlist/input.bzl", "my_namespace")
+
 my_namespace.min(<a href="#my_namespace.min-integers">integers</a>)
 </pre>
 
@@ -48,6 +50,7 @@ Returns the minimum of given elements.
 
 <pre>
 load("@stardoc//test:testdata/multi_level_namespace_test_with_allowlist/input.bzl", "other_namespace")
+
 other_namespace.foo.nothing()
 </pre>
 

--- a/test/testdata/multiple_files_test/golden.md
+++ b/test/testdata/multiple_files_test/golden.md
@@ -8,6 +8,7 @@ A direct dependency file of the input file.
 
 <pre>
 load("@stardoc//test:testdata/multiple_files_test/input.bzl", "my_rule")
+
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-second">second</a>)
 </pre>
 
@@ -29,6 +30,7 @@ This is my rule. It does stuff.
 
 <pre>
 load("@stardoc//test:testdata/multiple_files_test/input.bzl", "other_rule")
+
 other_rule(<a href="#other_rule-name">name</a>, <a href="#other_rule-fourth">fourth</a>, <a href="#other_rule-third">third</a>)
 </pre>
 
@@ -50,6 +52,7 @@ This is another rule.
 
 <pre>
 load("@stardoc//test:testdata/multiple_files_test/input.bzl", "yet_another_rule")
+
 yet_another_rule(<a href="#yet_another_rule-name">name</a>, <a href="#yet_another_rule-fifth">fifth</a>)
 </pre>
 
@@ -70,6 +73,7 @@ This is yet another rule
 
 <pre>
 load("@stardoc//test:testdata/multiple_files_test/input.bzl", "top_fun")
+
 top_fun(<a href="#top_fun-a">a</a>, <a href="#top_fun-b">b</a>, <a href="#top_fun-c">c</a>)
 </pre>
 

--- a/test/testdata/multiple_files_test/golden.md
+++ b/test/testdata/multiple_files_test/golden.md
@@ -7,6 +7,7 @@ A direct dependency file of the input file.
 ## my_rule
 
 <pre>
+load("@stardoc//test:testdata/multiple_files_test/input.bzl", "my_rule")
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-second">second</a>)
 </pre>
 
@@ -27,6 +28,7 @@ This is my rule. It does stuff.
 ## other_rule
 
 <pre>
+load("@stardoc//test:testdata/multiple_files_test/input.bzl", "other_rule")
 other_rule(<a href="#other_rule-name">name</a>, <a href="#other_rule-fourth">fourth</a>, <a href="#other_rule-third">third</a>)
 </pre>
 
@@ -47,6 +49,7 @@ This is another rule.
 ## yet_another_rule
 
 <pre>
+load("@stardoc//test:testdata/multiple_files_test/input.bzl", "yet_another_rule")
 yet_another_rule(<a href="#yet_another_rule-name">name</a>, <a href="#yet_another_rule-fifth">fifth</a>)
 </pre>
 
@@ -66,6 +69,7 @@ This is yet another rule
 ## top_fun
 
 <pre>
+load("@stardoc//test:testdata/multiple_files_test/input.bzl", "top_fun")
 top_fun(<a href="#top_fun-a">a</a>, <a href="#top_fun-b">b</a>, <a href="#top_fun-c">c</a>)
 </pre>
 

--- a/test/testdata/multiple_files_test/noenable_bzlmod_golden.md
+++ b/test/testdata/multiple_files_test/noenable_bzlmod_golden.md
@@ -1,0 +1,91 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+A direct dependency file of the input file.
+
+<a id="my_rule"></a>
+
+## my_rule
+
+<pre>
+load("@io_bazel_stardoc//test:testdata/multiple_files_test/input.bzl", "my_rule")
+
+my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-second">second</a>)
+</pre>
+
+This is my rule. It does stuff.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="my_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="my_rule-first"></a>first |  first my_rule doc string   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="my_rule-second"></a>second |  -   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | required |  |
+
+
+<a id="other_rule"></a>
+
+## other_rule
+
+<pre>
+load("@io_bazel_stardoc//test:testdata/multiple_files_test/input.bzl", "other_rule")
+
+other_rule(<a href="#other_rule-name">name</a>, <a href="#other_rule-fourth">fourth</a>, <a href="#other_rule-third">third</a>)
+</pre>
+
+This is another rule.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="other_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="other_rule-fourth"></a>fourth |  -   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | required |  |
+| <a id="other_rule-third"></a>third |  third other_rule doc string   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+
+
+<a id="yet_another_rule"></a>
+
+## yet_another_rule
+
+<pre>
+load("@io_bazel_stardoc//test:testdata/multiple_files_test/input.bzl", "yet_another_rule")
+
+yet_another_rule(<a href="#yet_another_rule-name">name</a>, <a href="#yet_another_rule-fifth">fifth</a>)
+</pre>
+
+This is yet another rule
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="yet_another_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="yet_another_rule-fifth"></a>fifth |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+
+
+<a id="top_fun"></a>
+
+## top_fun
+
+<pre>
+load("@io_bazel_stardoc//test:testdata/multiple_files_test/input.bzl", "top_fun")
+
+top_fun(<a href="#top_fun-a">a</a>, <a href="#top_fun-b">b</a>, <a href="#top_fun-c">c</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="top_fun-a"></a>a |  <p align="center"> - </p>   |  none |
+| <a id="top_fun-b"></a>b |  <p align="center"> - </p>   |  none |
+| <a id="top_fun-c"></a>c |  <p align="center"> - </p>   |  none |
+
+

--- a/test/testdata/multiple_rules_test/golden.md
+++ b/test/testdata/multiple_rules_test/golden.md
@@ -7,6 +7,7 @@
 ## my_rule
 
 <pre>
+load("@stardoc//test:testdata/multiple_rules_test/input.bzl", "my_rule")
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-second">second</a>)
 </pre>
 
@@ -27,6 +28,7 @@ This is my rule. It does stuff.
 ## other_rule
 
 <pre>
+load("@stardoc//test:testdata/multiple_rules_test/input.bzl", "other_rule")
 other_rule(<a href="#other_rule-name">name</a>, <a href="#other_rule-fourth">fourth</a>, <a href="#other_rule-third">third</a>)
 </pre>
 
@@ -47,6 +49,7 @@ This is another rule.
 ## yet_another_rule
 
 <pre>
+load("@stardoc//test:testdata/multiple_rules_test/input.bzl", "yet_another_rule")
 yet_another_rule(<a href="#yet_another_rule-name">name</a>, <a href="#yet_another_rule-fifth">fifth</a>)
 </pre>
 
@@ -66,6 +69,7 @@ This is yet another rule
 ## my_rule_impl
 
 <pre>
+load("@stardoc//test:testdata/multiple_rules_test/input.bzl", "my_rule_impl")
 my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 </pre>
 

--- a/test/testdata/multiple_rules_test/golden.md
+++ b/test/testdata/multiple_rules_test/golden.md
@@ -8,6 +8,7 @@
 
 <pre>
 load("@stardoc//test:testdata/multiple_rules_test/input.bzl", "my_rule")
+
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-second">second</a>)
 </pre>
 
@@ -29,6 +30,7 @@ This is my rule. It does stuff.
 
 <pre>
 load("@stardoc//test:testdata/multiple_rules_test/input.bzl", "other_rule")
+
 other_rule(<a href="#other_rule-name">name</a>, <a href="#other_rule-fourth">fourth</a>, <a href="#other_rule-third">third</a>)
 </pre>
 
@@ -50,6 +52,7 @@ This is another rule.
 
 <pre>
 load("@stardoc//test:testdata/multiple_rules_test/input.bzl", "yet_another_rule")
+
 yet_another_rule(<a href="#yet_another_rule-name">name</a>, <a href="#yet_another_rule-fifth">fifth</a>)
 </pre>
 
@@ -70,6 +73,7 @@ This is yet another rule
 
 <pre>
 load("@stardoc//test:testdata/multiple_rules_test/input.bzl", "my_rule_impl")
+
 my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 </pre>
 

--- a/test/testdata/namespace_test/golden.md
+++ b/test/testdata/namespace_test/golden.md
@@ -7,6 +7,7 @@ A test that verifies documenting a namespace of functions.
 ## my_namespace.assert_non_empty
 
 <pre>
+load("@stardoc//test:testdata/namespace_test/input.bzl", "my_namespace")
 my_namespace.assert_non_empty(<a href="#my_namespace.assert_non_empty-some_list">some_list</a>, <a href="#my_namespace.assert_non_empty-other_list">other_list</a>)
 </pre>
 
@@ -26,6 +27,7 @@ Asserts the two given lists are not empty.
 ## my_namespace.join_strings
 
 <pre>
+load("@stardoc//test:testdata/namespace_test/input.bzl", "my_namespace")
 my_namespace.join_strings(<a href="#my_namespace.join_strings-strings">strings</a>, <a href="#my_namespace.join_strings-delimiter">delimiter</a>)
 </pre>
 
@@ -49,6 +51,7 @@ The joined string.
 ## my_namespace.min
 
 <pre>
+load("@stardoc//test:testdata/namespace_test/input.bzl", "my_namespace")
 my_namespace.min(<a href="#my_namespace.min-integers">integers</a>)
 </pre>
 

--- a/test/testdata/namespace_test/golden.md
+++ b/test/testdata/namespace_test/golden.md
@@ -8,6 +8,7 @@ A test that verifies documenting a namespace of functions.
 
 <pre>
 load("@stardoc//test:testdata/namespace_test/input.bzl", "my_namespace")
+
 my_namespace.assert_non_empty(<a href="#my_namespace.assert_non_empty-some_list">some_list</a>, <a href="#my_namespace.assert_non_empty-other_list">other_list</a>)
 </pre>
 
@@ -28,6 +29,7 @@ Asserts the two given lists are not empty.
 
 <pre>
 load("@stardoc//test:testdata/namespace_test/input.bzl", "my_namespace")
+
 my_namespace.join_strings(<a href="#my_namespace.join_strings-strings">strings</a>, <a href="#my_namespace.join_strings-delimiter">delimiter</a>)
 </pre>
 
@@ -52,6 +54,7 @@ The joined string.
 
 <pre>
 load("@stardoc//test:testdata/namespace_test/input.bzl", "my_namespace")
+
 my_namespace.min(<a href="#my_namespace.min-integers">integers</a>)
 </pre>
 

--- a/test/testdata/provider_basic_test/golden.md
+++ b/test/testdata/provider_basic_test/golden.md
@@ -7,6 +7,7 @@
 ## MyFooInfo
 
 <pre>
+load("@stardoc//test:testdata/provider_basic_test/input.bzl", "MyFooInfo")
 MyFooInfo(<a href="#MyFooInfo-bar">bar</a>, <a href="#MyFooInfo-baz">baz</a>)
 </pre>
 
@@ -26,6 +27,7 @@ Stores information about a foo.
 ## MyPoorlyDocumentedInfo
 
 <pre>
+load("@stardoc//test:testdata/provider_basic_test/input.bzl", "MyPoorlyDocumentedInfo")
 MyPoorlyDocumentedInfo()
 </pre>
 
@@ -40,6 +42,7 @@ MyPoorlyDocumentedInfo()
 ## MyVeryDocumentedInfo
 
 <pre>
+load("@stardoc//test:testdata/provider_basic_test/input.bzl", "MyVeryDocumentedInfo")
 MyVeryDocumentedInfo(<a href="#MyVeryDocumentedInfo-favorite_food">favorite_food</a>, <a href="#MyVeryDocumentedInfo-favorite_color">favorite_color</a>)
 </pre>
 

--- a/test/testdata/provider_basic_test/golden.md
+++ b/test/testdata/provider_basic_test/golden.md
@@ -8,6 +8,7 @@
 
 <pre>
 load("@stardoc//test:testdata/provider_basic_test/input.bzl", "MyFooInfo")
+
 MyFooInfo(<a href="#MyFooInfo-bar">bar</a>, <a href="#MyFooInfo-baz">baz</a>)
 </pre>
 
@@ -28,6 +29,7 @@ Stores information about a foo.
 
 <pre>
 load("@stardoc//test:testdata/provider_basic_test/input.bzl", "MyPoorlyDocumentedInfo")
+
 MyPoorlyDocumentedInfo()
 </pre>
 
@@ -43,6 +45,7 @@ MyPoorlyDocumentedInfo()
 
 <pre>
 load("@stardoc//test:testdata/provider_basic_test/input.bzl", "MyVeryDocumentedInfo")
+
 MyVeryDocumentedInfo(<a href="#MyVeryDocumentedInfo-favorite_food">favorite_food</a>, <a href="#MyVeryDocumentedInfo-favorite_color">favorite_color</a>)
 </pre>
 

--- a/test/testdata/providers_for_attributes_test/golden.md
+++ b/test/testdata/providers_for_attributes_test/golden.md
@@ -8,6 +8,7 @@ The input file for the providers for attributes test
 
 <pre>
 load("@stardoc//test:testdata/providers_for_attributes_test/input.bzl", "my_rule")
+
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-fifth">fifth</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-fourth">fourth</a>, <a href="#my_rule-second">second</a>, <a href="#my_rule-sixth">sixth</a>, <a href="#my_rule-third">third</a>)
 </pre>
 
@@ -33,6 +34,7 @@ This rule does things.
 
 <pre>
 load("@stardoc//test:testdata/providers_for_attributes_test/input.bzl", "MyProviderInfo")
+
 MyProviderInfo(<a href="#MyProviderInfo-foo">foo</a>, <a href="#MyProviderInfo-bar">bar</a>)
 </pre>
 
@@ -53,6 +55,7 @@ MyProviderInfo(<a href="#MyProviderInfo-foo">foo</a>, <a href="#MyProviderInfo-b
 
 <pre>
 load("@stardoc//test:testdata/providers_for_attributes_test/input.bzl", "OtherProviderInfo")
+
 OtherProviderInfo()
 </pre>
 
@@ -68,6 +71,7 @@ OtherProviderInfo()
 
 <pre>
 load("@stardoc//test:testdata/providers_for_attributes_test/input.bzl", "my_rule_impl")
+
 my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 </pre>
 

--- a/test/testdata/providers_for_attributes_test/golden.md
+++ b/test/testdata/providers_for_attributes_test/golden.md
@@ -7,6 +7,7 @@ The input file for the providers for attributes test
 ## my_rule
 
 <pre>
+load("@stardoc//test:testdata/providers_for_attributes_test/input.bzl", "my_rule")
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-fifth">fifth</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-fourth">fourth</a>, <a href="#my_rule-second">second</a>, <a href="#my_rule-sixth">sixth</a>, <a href="#my_rule-third">third</a>)
 </pre>
 
@@ -31,6 +32,7 @@ This rule does things.
 ## MyProviderInfo
 
 <pre>
+load("@stardoc//test:testdata/providers_for_attributes_test/input.bzl", "MyProviderInfo")
 MyProviderInfo(<a href="#MyProviderInfo-foo">foo</a>, <a href="#MyProviderInfo-bar">bar</a>)
 </pre>
 
@@ -50,6 +52,7 @@ MyProviderInfo(<a href="#MyProviderInfo-foo">foo</a>, <a href="#MyProviderInfo-b
 ## OtherProviderInfo
 
 <pre>
+load("@stardoc//test:testdata/providers_for_attributes_test/input.bzl", "OtherProviderInfo")
 OtherProviderInfo()
 </pre>
 
@@ -64,6 +67,7 @@ OtherProviderInfo()
 ## my_rule_impl
 
 <pre>
+load("@stardoc//test:testdata/providers_for_attributes_test/input.bzl", "my_rule_impl")
 my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 </pre>
 

--- a/test/testdata/pure_markdown_template_test/golden.md
+++ b/test/testdata/pure_markdown_template_test/golden.md
@@ -8,6 +8,7 @@ Input file for markdown template test
 
 <pre>
 load("@stardoc//test:testdata/pure_markdown_template_test/input.bzl", "example_rule")
+
 example_rule(<a href="#example_rule-name">name</a>, <a href="#example_rule-first">first</a>, <a href="#example_rule-second">second</a>)
 </pre>
 
@@ -29,6 +30,7 @@ Small example of rule using a markdown template.
 
 <pre>
 load("@stardoc//test:testdata/pure_markdown_template_test/input.bzl", "ExampleProviderInfo")
+
 ExampleProviderInfo(<a href="#ExampleProviderInfo-foo">foo</a>, <a href="#ExampleProviderInfo-bar">bar</a>, <a href="#ExampleProviderInfo-baz">baz</a>)
 </pre>
 
@@ -50,6 +52,7 @@ Small example of provider using a markdown template.
 
 <pre>
 load("@stardoc//test:testdata/pure_markdown_template_test/input.bzl", "example_function")
+
 example_function(<a href="#example_function-foo">foo</a>, <a href="#example_function-bar">bar</a>)
 </pre>
 
@@ -70,8 +73,7 @@ Small example of function using a markdown template.
 
 <pre>
 load("@stardoc//test:testdata/pure_markdown_template_test/input.bzl", "example_aspect")
-# or on the command line:
-# --aspects=@stardoc//test:testdata/pure_markdown_template_test/input.bzl%example_aspect
+
 example_aspect(<a href="#example_aspect-name">name</a>, <a href="#example_aspect-first">first</a>, <a href="#example_aspect-second">second</a>)
 </pre>
 

--- a/test/testdata/pure_markdown_template_test/golden.md
+++ b/test/testdata/pure_markdown_template_test/golden.md
@@ -7,6 +7,7 @@ Input file for markdown template test
 ## example_rule
 
 <pre>
+load("@stardoc//test:testdata/pure_markdown_template_test/input.bzl", "example_rule")
 example_rule(<a href="#example_rule-name">name</a>, <a href="#example_rule-first">first</a>, <a href="#example_rule-second">second</a>)
 </pre>
 
@@ -27,6 +28,7 @@ Small example of rule using a markdown template.
 ## ExampleProviderInfo
 
 <pre>
+load("@stardoc//test:testdata/pure_markdown_template_test/input.bzl", "ExampleProviderInfo")
 ExampleProviderInfo(<a href="#ExampleProviderInfo-foo">foo</a>, <a href="#ExampleProviderInfo-bar">bar</a>, <a href="#ExampleProviderInfo-baz">baz</a>)
 </pre>
 
@@ -47,6 +49,7 @@ Small example of provider using a markdown template.
 ## example_function
 
 <pre>
+load("@stardoc//test:testdata/pure_markdown_template_test/input.bzl", "example_function")
 example_function(<a href="#example_function-foo">foo</a>, <a href="#example_function-bar">bar</a>)
 </pre>
 
@@ -66,6 +69,9 @@ Small example of function using a markdown template.
 ## example_aspect
 
 <pre>
+load("@stardoc//test:testdata/pure_markdown_template_test/input.bzl", "example_aspect")
+# or on the command line:
+# --aspects=@stardoc//test:testdata/pure_markdown_template_test/input.bzl%example_aspect
 example_aspect(<a href="#example_aspect-name">name</a>, <a href="#example_aspect-first">first</a>, <a href="#example_aspect-second">second</a>)
 </pre>
 

--- a/test/testdata/py_rule_test/golden.md
+++ b/test/testdata/py_rule_test/golden.md
@@ -8,6 +8,7 @@ The input file for the python rule test
 
 <pre>
 load("@stardoc//test:testdata/py_rule_test/input.bzl", "py_related_rule")
+
 py_related_rule(<a href="#py_related_rule-name">name</a>, <a href="#py_related_rule-fifth">fifth</a>, <a href="#py_related_rule-first">first</a>, <a href="#py_related_rule-fourth">fourth</a>, <a href="#py_related_rule-second">second</a>, <a href="#py_related_rule-sixth">sixth</a>, <a href="#py_related_rule-third">third</a>)
 </pre>
 

--- a/test/testdata/py_rule_test/golden.md
+++ b/test/testdata/py_rule_test/golden.md
@@ -7,6 +7,7 @@ The input file for the python rule test
 ## py_related_rule
 
 <pre>
+load("@stardoc//test:testdata/py_rule_test/input.bzl", "py_related_rule")
 py_related_rule(<a href="#py_related_rule-name">name</a>, <a href="#py_related_rule-fifth">fifth</a>, <a href="#py_related_rule-first">first</a>, <a href="#py_related_rule-fourth">fourth</a>, <a href="#py_related_rule-second">second</a>, <a href="#py_related_rule-sixth">sixth</a>, <a href="#py_related_rule-third">third</a>)
 </pre>
 

--- a/test/testdata/repo_rules_test/golden.md
+++ b/test/testdata/repo_rules_test/golden.md
@@ -7,6 +7,7 @@
 ## my_repo
 
 <pre>
+load("@stardoc//test:testdata/repo_rules_test/input.bzl", "my_repo")
 my_repo(<a href="#my_repo-name">name</a>, <a href="#my_repo-repo_mapping">repo_mapping</a>, <a href="#my_repo-useless">useless</a>)
 </pre>
 

--- a/test/testdata/repo_rules_test/golden.md
+++ b/test/testdata/repo_rules_test/golden.md
@@ -8,6 +8,7 @@
 
 <pre>
 load("@stardoc//test:testdata/repo_rules_test/input.bzl", "my_repo")
+
 my_repo(<a href="#my_repo-name">name</a>, <a href="#my_repo-repo_mapping">repo_mapping</a>, <a href="#my_repo-useless">useless</a>)
 </pre>
 

--- a/test/testdata/same_level_file_test/BUILD
+++ b/test/testdata/same_level_file_test/BUILD
@@ -9,6 +9,7 @@ exports_files(
     [
         "dep.bzl",
         "golden.md",
+        "noenable_bzlmod_golden.md",
         "input.bzl",
     ],
 )

--- a/test/testdata/same_level_file_test/golden.md
+++ b/test/testdata/same_level_file_test/golden.md
@@ -7,6 +7,7 @@
 ## my_rule
 
 <pre>
+load("@stardoc//test/testdata/same_level_file_test:input.bzl", "my_rule")
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-second">second</a>)
 </pre>
 

--- a/test/testdata/same_level_file_test/golden.md
+++ b/test/testdata/same_level_file_test/golden.md
@@ -8,6 +8,7 @@
 
 <pre>
 load("@stardoc//test/testdata/same_level_file_test:input.bzl", "my_rule")
+
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-second">second</a>)
 </pre>
 

--- a/test/testdata/same_level_file_test/noenable_bzlmod_golden.md
+++ b/test/testdata/same_level_file_test/noenable_bzlmod_golden.md
@@ -1,0 +1,26 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+
+
+<a id="my_rule"></a>
+
+## my_rule
+
+<pre>
+load("@io_bazel_stardoc//test/testdata/same_level_file_test:input.bzl", "my_rule")
+
+my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-second">second</a>)
+</pre>
+
+This is my rule. It does stuff.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="my_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="my_rule-first"></a>first |  first my_rule doc string   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="my_rule-second"></a>second |  -   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | required |  |
+
+

--- a/test/testdata/simple_test/golden.md
+++ b/test/testdata/simple_test/golden.md
@@ -7,6 +7,7 @@
 ## my_rule
 
 <pre>
+load("@stardoc//test:testdata/simple_test/input.bzl", "my_rule")
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-fourth">fourth</a>, <a href="#my_rule-second">second</a>, <a href="#my_rule-third">third</a>)
 </pre>
 

--- a/test/testdata/simple_test/golden.md
+++ b/test/testdata/simple_test/golden.md
@@ -8,6 +8,7 @@
 
 <pre>
 load("@stardoc//test:testdata/simple_test/input.bzl", "my_rule")
+
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-fourth">fourth</a>, <a href="#my_rule-second">second</a>, <a href="#my_rule-third">third</a>)
 </pre>
 

--- a/test/testdata/struct_default_value_test/golden.md
+++ b/test/testdata/struct_default_value_test/golden.md
@@ -8,6 +8,7 @@ The input file for struct default values test
 
 <pre>
 load("@stardoc//test:testdata/struct_default_value_test/input.bzl", "check_struct_default_values")
+
 check_struct_default_values(<a href="#check_struct_default_values-struct_no_args">struct_no_args</a>, <a href="#check_struct_default_values-struct_arg">struct_arg</a>, <a href="#check_struct_default_values-struct_args">struct_args</a>, <a href="#check_struct_default_values-struct_int_args">struct_int_args</a>,
                             <a href="#check_struct_default_values-struct_struct_args">struct_struct_args</a>)
 </pre>

--- a/test/testdata/struct_default_value_test/golden.md
+++ b/test/testdata/struct_default_value_test/golden.md
@@ -7,6 +7,7 @@ The input file for struct default values test
 ## check_struct_default_values
 
 <pre>
+load("@stardoc//test:testdata/struct_default_value_test/input.bzl", "check_struct_default_values")
 check_struct_default_values(<a href="#check_struct_default_values-struct_no_args">struct_no_args</a>, <a href="#check_struct_default_values-struct_arg">struct_arg</a>, <a href="#check_struct_default_values-struct_args">struct_args</a>, <a href="#check_struct_default_values-struct_int_args">struct_int_args</a>,
                             <a href="#check_struct_default_values-struct_struct_args">struct_struct_args</a>)
 </pre>

--- a/test/testdata/table_of_contents_test/golden.md
+++ b/test/testdata/table_of_contents_test/golden.md
@@ -36,6 +36,7 @@ Test rules / providers / etc for the table of contents generation test.
 ## my_rule
 
 <pre>
+load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "my_rule")
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-fourth">fourth</a>, <a href="#my_rule-second">second</a>, <a href="#my_rule-third">third</a>)
 </pre>
 
@@ -58,6 +59,7 @@ This is my rule. It does stuff.
 ## MyFooInfo
 
 <pre>
+load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "MyFooInfo")
 MyFooInfo(<a href="#MyFooInfo-bar">bar</a>, <a href="#MyFooInfo-baz">baz</a>)
 </pre>
 
@@ -77,6 +79,7 @@ Stores information about a foo.
 ## MyVeryDocumentedInfo
 
 <pre>
+load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "MyVeryDocumentedInfo")
 MyVeryDocumentedInfo(<a href="#MyVeryDocumentedInfo-favorite_food">favorite_food</a>, <a href="#MyVeryDocumentedInfo-favorite_color">favorite_color</a>)
 </pre>
 
@@ -98,6 +101,7 @@ Look on my works, ye mighty, and despair!
 ## check_sources
 
 <pre>
+load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "check_sources")
 check_sources(<a href="#check_sources-name">name</a>, <a href="#check_sources-required_param">required_param</a>, <a href="#check_sources-bool_param">bool_param</a>, <a href="#check_sources-srcs">srcs</a>, <a href="#check_sources-string_param">string_param</a>, <a href="#check_sources-int_param">int_param</a>, <a href="#check_sources-dict_param">dict_param</a>,
               <a href="#check_sources-struct_param">struct_param</a>)
 </pre>
@@ -128,6 +132,7 @@ Use `bazel build` to run the check.
 ## returns_a_thing
 
 <pre>
+load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "returns_a_thing")
 returns_a_thing(<a href="#returns_a_thing-name">name</a>)
 </pre>
 
@@ -150,6 +155,9 @@ A suffixed version of the name.
 ## my_aspect
 
 <pre>
+load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "my_aspect")
+# or on the command line:
+# --aspects=@stardoc//test:testdata/table_of_contents_test/input.bzl%my_aspect
 my_aspect(<a href="#my_aspect-name">name</a>, <a href="#my_aspect-first">first</a>, <a href="#my_aspect-second">second</a>)
 </pre>
 
@@ -181,6 +189,9 @@ It does stuff.
 ## other_aspect
 
 <pre>
+load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "other_aspect")
+# or on the command line:
+# --aspects=@stardoc//test:testdata/table_of_contents_test/input.bzl%other_aspect
 other_aspect(<a href="#other_aspect-name">name</a>, <a href="#other_aspect-third">third</a>)
 </pre>
 
@@ -204,6 +215,7 @@ This is another aspect.
 ## my_repo
 
 <pre>
+load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "my_repo")
 my_repo(<a href="#my_repo-name">name</a>, <a href="#my_repo-repo_mapping">repo_mapping</a>, <a href="#my_repo-useless">useless</a>)
 </pre>
 

--- a/test/testdata/table_of_contents_test/golden.md
+++ b/test/testdata/table_of_contents_test/golden.md
@@ -37,6 +37,7 @@ Test rules / providers / etc for the table of contents generation test.
 
 <pre>
 load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "my_rule")
+
 my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-fourth">fourth</a>, <a href="#my_rule-second">second</a>, <a href="#my_rule-third">third</a>)
 </pre>
 
@@ -60,6 +61,7 @@ This is my rule. It does stuff.
 
 <pre>
 load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "MyFooInfo")
+
 MyFooInfo(<a href="#MyFooInfo-bar">bar</a>, <a href="#MyFooInfo-baz">baz</a>)
 </pre>
 
@@ -80,6 +82,7 @@ Stores information about a foo.
 
 <pre>
 load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "MyVeryDocumentedInfo")
+
 MyVeryDocumentedInfo(<a href="#MyVeryDocumentedInfo-favorite_food">favorite_food</a>, <a href="#MyVeryDocumentedInfo-favorite_color">favorite_color</a>)
 </pre>
 
@@ -102,6 +105,7 @@ Look on my works, ye mighty, and despair!
 
 <pre>
 load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "check_sources")
+
 check_sources(<a href="#check_sources-name">name</a>, <a href="#check_sources-required_param">required_param</a>, <a href="#check_sources-bool_param">bool_param</a>, <a href="#check_sources-srcs">srcs</a>, <a href="#check_sources-string_param">string_param</a>, <a href="#check_sources-int_param">int_param</a>, <a href="#check_sources-dict_param">dict_param</a>,
               <a href="#check_sources-struct_param">struct_param</a>)
 </pre>
@@ -133,6 +137,7 @@ Use `bazel build` to run the check.
 
 <pre>
 load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "returns_a_thing")
+
 returns_a_thing(<a href="#returns_a_thing-name">name</a>)
 </pre>
 
@@ -156,8 +161,7 @@ A suffixed version of the name.
 
 <pre>
 load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "my_aspect")
-# or on the command line:
-# --aspects=@stardoc//test:testdata/table_of_contents_test/input.bzl%my_aspect
+
 my_aspect(<a href="#my_aspect-name">name</a>, <a href="#my_aspect-first">first</a>, <a href="#my_aspect-second">second</a>)
 </pre>
 
@@ -190,8 +194,7 @@ It does stuff.
 
 <pre>
 load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "other_aspect")
-# or on the command line:
-# --aspects=@stardoc//test:testdata/table_of_contents_test/input.bzl%other_aspect
+
 other_aspect(<a href="#other_aspect-name">name</a>, <a href="#other_aspect-third">third</a>)
 </pre>
 
@@ -216,6 +219,7 @@ This is another aspect.
 
 <pre>
 load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "my_repo")
+
 my_repo(<a href="#my_repo-name">name</a>, <a href="#my_repo-repo_mapping">repo_mapping</a>, <a href="#my_repo-useless">useless</a>)
 </pre>
 

--- a/test/testdata/table_of_contents_test/noenable_bzlmod_golden.md
+++ b/test/testdata/table_of_contents_test/noenable_bzlmod_golden.md
@@ -1,0 +1,283 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Test rules / providers / etc for the table of contents generation test.
+
+
+## Rules
+
+- [my_rule](#my_rule)
+
+## Providers
+
+- [MyFooInfo](#MyFooInfo)
+- [MyVeryDocumentedInfo](#MyVeryDocumentedInfo)
+
+## Functions
+
+- [check_sources](#check_sources)
+- [returns_a_thing](#returns_a_thing)
+
+## Aspects
+
+- [my_aspect](#my_aspect)
+- [other_aspect](#other_aspect)
+
+## Repository Rules
+
+- [my_repo](#my_repo)
+
+## Module Extensions
+
+- [my_ext](#my_ext)
+
+
+<a id="my_rule"></a>
+
+## my_rule
+
+<pre>
+load("@io_bazel_stardoc//test:testdata/table_of_contents_test/input.bzl", "my_rule")
+
+my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-fourth">fourth</a>, <a href="#my_rule-second">second</a>, <a href="#my_rule-third">third</a>)
+</pre>
+
+This is my rule. It does stuff.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="my_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="my_rule-first"></a>first |  first doc string   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="my_rule-fourth"></a>fourth |  fourth doc string   | Boolean | optional |  `False`  |
+| <a id="my_rule-second"></a>second |  -   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | required |  |
+| <a id="my_rule-third"></a>third |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+
+
+<a id="MyFooInfo"></a>
+
+## MyFooInfo
+
+<pre>
+load("@io_bazel_stardoc//test:testdata/table_of_contents_test/input.bzl", "MyFooInfo")
+
+MyFooInfo(<a href="#MyFooInfo-bar">bar</a>, <a href="#MyFooInfo-baz">baz</a>)
+</pre>
+
+Stores information about a foo.
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="MyFooInfo-bar"></a>bar |  -    |
+| <a id="MyFooInfo-baz"></a>baz |  -    |
+
+
+<a id="MyVeryDocumentedInfo"></a>
+
+## MyVeryDocumentedInfo
+
+<pre>
+load("@io_bazel_stardoc//test:testdata/table_of_contents_test/input.bzl", "MyVeryDocumentedInfo")
+
+MyVeryDocumentedInfo(<a href="#MyVeryDocumentedInfo-favorite_food">favorite_food</a>, <a href="#MyVeryDocumentedInfo-favorite_color">favorite_color</a>)
+</pre>
+
+A provider with some really neat documentation.
+
+Look on my works, ye mighty, and despair!
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="MyVeryDocumentedInfo-favorite_food"></a>favorite_food |  A string representing my favorite food<br><br>Expected to be delicious.    |
+| <a id="MyVeryDocumentedInfo-favorite_color"></a>favorite_color |  A string representing my favorite color    |
+
+
+<a id="check_sources"></a>
+
+## check_sources
+
+<pre>
+load("@io_bazel_stardoc//test:testdata/table_of_contents_test/input.bzl", "check_sources")
+
+check_sources(<a href="#check_sources-name">name</a>, <a href="#check_sources-required_param">required_param</a>, <a href="#check_sources-bool_param">bool_param</a>, <a href="#check_sources-srcs">srcs</a>, <a href="#check_sources-string_param">string_param</a>, <a href="#check_sources-int_param">int_param</a>, <a href="#check_sources-dict_param">dict_param</a>,
+              <a href="#check_sources-struct_param">struct_param</a>)
+</pre>
+
+Runs some checks on the given source files.
+
+This rule runs checks on a given set of source files.
+Use `bazel build` to run the check.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="check_sources-name"></a>name |  A unique name for this rule.   |  none |
+| <a id="check_sources-required_param"></a>required_param |  Use your imagination.   |  none |
+| <a id="check_sources-bool_param"></a>bool_param |  <p align="center"> - </p>   |  `True` |
+| <a id="check_sources-srcs"></a>srcs |  Source files to run the checks against.   |  `[]` |
+| <a id="check_sources-string_param"></a>string_param |  <p align="center"> - </p>   |  `""` |
+| <a id="check_sources-int_param"></a>int_param |  Your favorite number.   |  `2` |
+| <a id="check_sources-dict_param"></a>dict_param |  <p align="center"> - </p>   |  `{}` |
+| <a id="check_sources-struct_param"></a>struct_param |  <p align="center"> - </p>   |  `struct(foo = "bar")` |
+
+
+<a id="returns_a_thing"></a>
+
+## returns_a_thing
+
+<pre>
+load("@io_bazel_stardoc//test:testdata/table_of_contents_test/input.bzl", "returns_a_thing")
+
+returns_a_thing(<a href="#returns_a_thing-name">name</a>)
+</pre>
+
+Returns a suffixed name.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="returns_a_thing-name"></a>name |  A unique name for this rule.   |  none |
+
+**RETURNS**
+
+A suffixed version of the name.
+
+
+<a id="my_aspect"></a>
+
+## my_aspect
+
+<pre>
+load("@io_bazel_stardoc//test:testdata/table_of_contents_test/input.bzl", "my_aspect")
+
+my_aspect(<a href="#my_aspect-name">name</a>, <a href="#my_aspect-first">first</a>, <a href="#my_aspect-second">second</a>)
+</pre>
+
+This is my aspect.
+
+It does stuff.
+
+**ASPECT ATTRIBUTES**
+
+
+| Name | Type |
+| :------------- | :------------- |
+| deps| String |
+| attr_aspect| String |
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="my_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="my_aspect-first"></a>first |  -   | Boolean | required |  |
+| <a id="my_aspect-second"></a>second |  -   | String | required |  |
+
+
+<a id="other_aspect"></a>
+
+## other_aspect
+
+<pre>
+load("@io_bazel_stardoc//test:testdata/table_of_contents_test/input.bzl", "other_aspect")
+
+other_aspect(<a href="#other_aspect-name">name</a>, <a href="#other_aspect-third">third</a>)
+</pre>
+
+This is another aspect.
+
+**ASPECT ATTRIBUTES**
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="other_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="other_aspect-third"></a>third |  -   | Integer | required |  |
+
+
+<a id="my_repo"></a>
+
+## my_repo
+
+<pre>
+load("@io_bazel_stardoc//test:testdata/table_of_contents_test/input.bzl", "my_repo")
+
+my_repo(<a href="#my_repo-name">name</a>, <a href="#my_repo-repo_mapping">repo_mapping</a>, <a href="#my_repo-useless">useless</a>)
+</pre>
+
+Minimal example of a repository rule.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="my_repo-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="my_repo-repo_mapping"></a>repo_mapping |  In `WORKSPACE` context only: a dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<br><br>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).<br><br>This attribute is _not_ supported in `MODULE.bazel` context (when invoking a repository rule inside a module extension's implementation function).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  |
+| <a id="my_repo-useless"></a>useless |  This argument will be ignored.<br><br>You don't have to specify it, but you may.   | String | optional |  `"ignoreme"`  |
+
+**ENVIRONMENT VARIABLES**
+
+This repository rule depends on the following environment variables:
+
+* `FOO_CC`
+* `BAR_PATH`
+
+
+<a id="my_ext"></a>
+
+## my_ext
+
+<pre>
+my_ext = use_extension("@io_bazel_stardoc//test:testdata/table_of_contents_test/input.bzl", "my_ext")
+my_ext.install(<a href="#my_ext.install-artifacts">artifacts</a>)
+my_ext.artifact(<a href="#my_ext.artifact-artifact">artifact</a>, <a href="#my_ext.artifact-group">group</a>)
+</pre>
+
+Minimal example of a module extension.
+
+
+**TAG CLASSES**
+
+<a id="my_ext.install"></a>
+
+### install
+
+Install tag
+
+**Attributes**
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="my_ext.install-artifacts"></a>artifacts |  Install artifacts   | List of strings | optional |  `[]`  |
+
+<a id="my_ext.artifact"></a>
+
+### artifact
+
+Artifact tag
+
+**Attributes**
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="my_ext.artifact-artifact"></a>artifact |  Artifact   | String | required |  |
+| <a id="my_ext.artifact-group"></a>group |  Group name   | String | optional |  `"my_group"`  |
+
+

--- a/test/testdata/unknown_name_test/golden.md
+++ b/test/testdata/unknown_name_test/golden.md
@@ -7,6 +7,7 @@
 ## my_rule_impl
 
 <pre>
+load("@stardoc//test:testdata/unknown_name_test/input.bzl", "my_rule_impl")
 my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 </pre>
 

--- a/test/testdata/unknown_name_test/golden.md
+++ b/test/testdata/unknown_name_test/golden.md
@@ -8,6 +8,7 @@
 
 <pre>
 load("@stardoc//test:testdata/unknown_name_test/input.bzl", "my_rule_impl")
+
 my_rule_impl(<a href="#my_rule_impl-ctx">ctx</a>)
 </pre>
 


### PR DESCRIPTION
Rules, providers, functions and aspects now have a `load` statement in their summary. Aspects additionally include a copyable `--aspects` flag.

Fixes #95