### PR TITLE
Remove rendering test from distro tarball

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -48,7 +48,6 @@ filegroup(
         "rules_jvm_external.patch",
         "//src/main/java/com/google/devtools/build/skydoc/renderer:srcs",
         "//src/main/java/com/google/devtools/build/skydoc/rendering:srcs",
-        "//src/test/java/com/google/devtools/build/skydoc/rendering:srcs",
         "//stardoc:distro_srcs",
         "//stardoc/private:distro_srcs",
         "//stardoc/proto:distro_srcs",

--- a/src/test/java/com/google/devtools/build/skydoc/rendering/BUILD
+++ b/src/test/java/com/google/devtools/build/skydoc/rendering/BUILD
@@ -1,12 +1,6 @@
 load("@rules_java//java:defs.bzl", "java_test")
 
-package(
-    default_applicable_licenses = ["//:license"],
-    default_visibility = [
-        "//src:__subpackages__",
-        "//stardoc:__subpackages__",
-    ],
-)
+package(default_applicable_licenses = ["//:license"])
 
 filegroup(
     name = "srcs",


### PR DESCRIPTION
We already remove the integration tests from the distro tarball;
the rendering unit test is in there by mistake.