### PR TITLE
Remove explicit dependency on protobuf

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,6 @@ bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "rules_java", version = "6.3.0")
 bazel_dep(name = "rules_jvm_external", version = "5.2")
 bazel_dep(name = "rules_license", version = "0.0.7")
-bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
 
 # Maven artifacts required by Stardoc; keep consistent with deps.bzl
 STARDOC_MAVEN_ARTIFACTS = [

--- a/src/main/java/com/google/devtools/build/skydoc/renderer/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/renderer/BUILD
@@ -32,7 +32,6 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/skydoc/rendering",
         "//stardoc/proto:stardoc_output_java_proto",
-        "@com_google_protobuf//:protobuf_java",
         "@stardoc_maven//:com_beust_jcommander",
         "@stardoc_maven//:com_google_guava_guava",
     ],


### PR DESCRIPTION
With `--incompatible_enable_proto_toolchain_resolution`, the root module is supposed to provide a `proto_lang_toolchain` for Java, which injects the runtime. Hardcoded dependencies on the `protobuf` module would negate the benefits of supplying a toolchain with precompiled `protoc` and runtime.

Since the only used symbol from the protobuf runtime was an exception class, it has been replaced with a check for its class name. If more protobuf runtime symbols should be needed in the future, they should be obtained from a `current_java_proto_runtime` target that first looks for a `proto_lang_toolchain` for Java and only then falls back to the hardcoded reference.

The WORKSPACE deps macro still brings in `com_google_protobuf` as this may be the only source of the repo for users.