### PR TITLE
Render documentation for provider `init` callbacks

### DIFF
--- a/src/main/java/com/google/devtools/build/stardoc/renderer/RendererMain.java
+++ b/src/main/java/com/google/devtools/build/stardoc/renderer/RendererMain.java
@@ -46,6 +46,7 @@ import java.util.List;
  */
 public final class RendererMain {
 
+  @SuppressWarnings("ProtoParseWithRegistry") // See https://github.com/bazelbuild/stardoc/pull/221
   public static void main(String[] args) throws IOException {
 
     RendererOptions rendererOptions = new RendererOptions();

--- a/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownRenderer.java
+++ b/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownRenderer.java
@@ -14,12 +14,17 @@
 
 package com.google.devtools.build.stardoc.rendering;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.AspectInfo;
+import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.FunctionParamInfo;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.ModuleExtensionInfo;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.ModuleInfo;
+import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.ProviderFieldInfo;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.ProviderInfo;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.RepositoryRuleInfo;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.RuleInfo;
@@ -157,8 +162,65 @@ public class MarkdownRenderer {
   /**
    * Returns a markdown rendering of provider documentation for the given provider information
    * object with the given name.
+   *
+   * <p>For evaluating the provider template, populates the the following constants:
+   *
+   * <ul>
+   *   <li>util - a {@link MarkdownUtil} object
+   *   <li>providerName - the provider's name
+   *   <li>providerInfo - the {@link ProviderInfo} proto
+   *   <li>initParamsWithInferredDocs - the list of the init callback's {@link FunctionParamInfo}
+   *       protos, with any undocumented parameters inheriting the doc string of the provider's
+   *       field with the same name; or an empty list of the provider doesn't have an init callback
+   *   <li>initParamNamesEqualFieldNames - true iff the provider has an init callback and the set of
+   *       names of the init callback's parameters equals the set of names of the provider's fields
+   *   <li>initParamsHaveDefaultValues - true iff the provider has an init callback and at least one
+   *       of the init callback's parameters has a default value specified
+   *   <li>initParamsHaveDistinctDocs - true iff the provider has an init callback and at least one
+   *       of the init callback's parameters has a docstring which is non-empty and not equal to the
+   *       corresponding field's docstring.
+   * </ul>
    */
   public String render(ProviderInfo providerInfo) throws IOException {
+    ImmutableMap.Builder<String, String> fieldDocsBuilder = ImmutableMap.builder();
+    for (ProviderFieldInfo fieldInfo : providerInfo.getFieldInfoList()) {
+      fieldDocsBuilder.put(fieldInfo.getName(), fieldInfo.getDocString());
+    }
+    ImmutableMap<String, String> fieldDocs = fieldDocsBuilder.buildOrThrow();
+
+    ImmutableList<FunctionParamInfo> initParamsWithInferredDocs;
+    if (providerInfo.hasInit()) {
+      initParamsWithInferredDocs =
+          providerInfo.getInit().getParameterList().stream()
+              .map(param -> withInferredDoc(param, fieldDocs))
+              .collect(toImmutableList());
+    } else {
+      initParamsWithInferredDocs = ImmutableList.of();
+    }
+    boolean initParamNamesEqualFieldNames =
+        providerInfo.hasInit()
+            && providerInfo.getInit().getParameterList().stream()
+                .map(FunctionParamInfo::getName)
+                .collect(toImmutableSet())
+                .equals(
+                    providerInfo.getFieldInfoList().stream()
+                        .map(ProviderFieldInfo::getName)
+                        .collect(toImmutableSet()));
+    boolean initParamsHaveDefaultValues =
+        providerInfo.hasInit()
+            && providerInfo.getInit().getParameterList().stream()
+                .filter(param -> !param.getDefaultValue().isEmpty())
+                .findFirst()
+                .isPresent();
+    boolean initParamsHaveDistinctDocs =
+        providerInfo.hasInit()
+            && providerInfo.getInit().getParameterList().stream()
+                .filter(
+                    param ->
+                        !param.getDocString().isEmpty()
+                            && !param.getDocString().equals(fieldDocs.get(param.getName())))
+                .findFirst()
+                .isPresent();
     ImmutableMap<String, Object> vars =
         ImmutableMap.of(
             "util",
@@ -166,12 +228,32 @@ public class MarkdownRenderer {
             "providerName",
             providerInfo.getProviderName(),
             "providerInfo",
-            providerInfo);
+            providerInfo,
+            "initParamsWithInferredDocs",
+            initParamsWithInferredDocs,
+            "initParamNamesEqualFieldNames",
+            initParamNamesEqualFieldNames,
+            "initParamsHaveDefaultValues",
+            initParamsHaveDefaultValues,
+            "initParamsHaveDistinctDocs",
+            initParamsHaveDistinctDocs);
     Reader reader = readerFromPath(providerTemplateFilename);
     try {
       return Template.parseFrom(reader).evaluate(vars);
     } catch (ParseException | EvaluationException e) {
       throw new IOException(e);
+    }
+  }
+
+  private static FunctionParamInfo withInferredDoc(
+      FunctionParamInfo paramInfo, ImmutableMap<String, String> fallbackDocs) {
+    if (paramInfo.getDocString().isEmpty() && fallbackDocs.containsKey(paramInfo.getName())) {
+      return paramInfo.toBuilder()
+          .clearDocString()
+          .setDocString(fallbackDocs.get(paramInfo.getName()))
+          .build();
+    } else {
+      return paramInfo;
     }
   }
 

--- a/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownUtil.java
+++ b/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownUtil.java
@@ -232,20 +232,28 @@ public final class MarkdownUtil {
    */
   @SuppressWarnings("unused") // Used by markdown template.
   public String providerSummary(String providerName, ProviderInfo providerInfo) {
-    if (providerInfo.hasInit()) {
-      ImmutableList<String> paramNames =
-          providerInfo.getInit().getParameterList().stream()
-              .map(FunctionParamInfo::getName)
-              .collect(toImmutableList());
-      return summary(
-          providerName, paramNames, param -> String.format("%s-_init-%s", providerName, param));
-    } else {
-      ImmutableList<String> fieldNames =
-          providerInfo.getFieldInfoList().stream()
-              .map(field -> field.getName())
-              .collect(toImmutableList());
-      return summary(providerName, fieldNames);
-    }
+    return providerSummaryImpl(
+        providerName, providerInfo, param -> String.format("%s-%s", providerName, param));
+  }
+
+  /** Like {@link providerSummary}, but using "$providerName-_init" in HTML anchors. */
+  @SuppressWarnings("unused") // Used by markdown template.
+  public String providerSummaryWithInitAnchor(String providerName, ProviderInfo providerInfo) {
+    return providerSummaryImpl(
+        providerName, providerInfo, param -> String.format("%s-_init-%s", providerName, param));
+  }
+
+  private String providerSummaryImpl(
+      String providerName, ProviderInfo providerInfo, UnaryOperator<String> paramAnchorNamer) {
+    ImmutableList<String> paramNames =
+        providerInfo.hasInit()
+            ? providerInfo.getInit().getParameterList().stream()
+                .map(FunctionParamInfo::getName)
+                .collect(toImmutableList())
+            : providerInfo.getFieldInfoList().stream()
+                .map(field -> field.getName())
+                .collect(toImmutableList());
+    return summary(providerName, paramNames, paramAnchorNamer);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownUtil.java
+++ b/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownUtil.java
@@ -37,6 +37,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -223,15 +224,28 @@ public final class MarkdownUtil {
   /**
    * Return a string representing the summary for the given provider with the given name.
    *
-   * <p>For example: 'MyInfo(foo, bar)'. The summary will contain hyperlinks for each field.
+   * <p>For example: 'MyInfo(foo, bar)'.
+   *
+   * <p>If the provider has an init callback, the summary will contain hyperlinks for each of the
+   * init callback's parameters; if the provider doesn't have an init callback, the summary will
+   * contain hyperlinks for each field.
    */
   @SuppressWarnings("unused") // Used by markdown template.
   public String providerSummary(String providerName, ProviderInfo providerInfo) {
-    ImmutableList<String> fieldNames =
-        providerInfo.getFieldInfoList().stream()
-            .map(field -> field.getName())
-            .collect(toImmutableList());
-    return summary(providerName, fieldNames);
+    if (providerInfo.hasInit()) {
+      ImmutableList<String> paramNames =
+          providerInfo.getInit().getParameterList().stream()
+              .map(FunctionParamInfo::getName)
+              .collect(toImmutableList());
+      return summary(
+          providerName, paramNames, param -> String.format("%s-_init-%s", providerName, param));
+    } else {
+      ImmutableList<String> fieldNames =
+          providerInfo.getFieldInfoList().stream()
+              .map(field -> field.getName())
+              .collect(toImmutableList());
+      return summary(providerName, fieldNames);
+    }
   }
 
   /**
@@ -310,20 +324,34 @@ public final class MarkdownUtil {
     return summary(funcInfo.getFunctionName(), paramNames);
   }
 
-  private static String summary(String functionName, ImmutableList<String> paramNames) {
+  /**
+   * Returns a string representing the summary for a function or other callable.
+   *
+   * @param paramAnchorNamer translates a paremeter's name into the name of its HTML anchor
+   */
+  private static String summary(
+      String functionName,
+      ImmutableList<String> paramNames,
+      UnaryOperator<String> paramAnchorNamer) {
     ImmutableList<ImmutableList<String>> paramLines =
         wrap(functionName, paramNames, MAX_LINE_LENGTH);
     List<String> paramLinksLines = new ArrayList<>();
     for (List<String> params : paramLines) {
       String paramLinksLine =
           params.stream()
-              .map(param -> String.format("<a href=\"#%s-%s\">%s</a>", functionName, param, param))
+              .map(
+                  param ->
+                      String.format("<a href=\"#%s\">%s</a>", paramAnchorNamer.apply(param), param))
               .collect(joining(", "));
       paramLinksLines.add(paramLinksLine);
     }
     String paramList =
         Joiner.on(",\n" + " ".repeat(functionName.length() + 1)).join(paramLinksLines);
     return String.format("%s(%s)", functionName, paramList);
+  }
+
+  private static String summary(String functionName, ImmutableList<String> paramNames) {
+    return summary(functionName, paramNames, param -> String.format("%s-%s", functionName, param));
   }
 
   /**

--- a/stardoc/templates/html_tables/provider.vm
+++ b/stardoc/templates/html_tables/provider.vm
@@ -5,12 +5,10 @@
 <pre>
 ${util.providerSummary($providerName, $providerInfo)}
 </pre>
-#if ($providerInfo.hasInit() && !$providerInfo.init.docString.isEmpty())
-
-${providerInfo.init.docString}
-#end
+#if (!$providerInfo.docString.isEmpty())
 
 ${providerInfo.docString}
+#end
 #if ($providerInfo.hasInit() && !$providerInfo.init.deprecated.docString.isEmpty())
 
 #[[###]]# Deprecated

--- a/stardoc/templates/html_tables/provider.vm
+++ b/stardoc/templates/html_tables/provider.vm
@@ -5,8 +5,51 @@
 <pre>
 ${util.providerSummary($providerName, $providerInfo)}
 </pre>
+#if ($providerInfo.hasInit() && !$providerInfo.init.docString.isEmpty())
 
-${util.htmlEscape($providerInfo.docString)}
+${providerInfo.init.docString}
+#end
+
+${providerInfo.docString}
+#if ($providerInfo.hasInit() && !$providerInfo.init.deprecated.docString.isEmpty())
+
+#[[###]]# Deprecated
+
+${providerInfo.init.deprecated.docString}
+#end
+#if ($providerInfo.hasInit() && !$providerInfo.init.parameterList.isEmpty())
+
+#[[###]]# Constructor parameters
+
+<table class="params-table">
+<colgroup>
+<col class="col-param" />
+<col class="col-description" />
+</colgroup>
+<tbody>
+#foreach ($param in $providerInfo.init.parameterList)
+<tr id="${providerName}-_init-${param.name}">
+<td><code>${param.name}</code></td>
+<td>
+
+${util.mandatoryString($param)}.
+#if(!$param.getDefaultValue().isEmpty())
+default is <code>$param.getDefaultValue()</code>
+#end
+
+#if (!$param.docString.isEmpty())
+<p>
+
+${param.docString.trim()}
+
+</p>
+#end
+</td>
+</tr>
+#end
+</tbody>
+</table>
+#end
 
 #if (!$providerInfo.fieldInfoList.isEmpty())
 #[[###]]# Fields

--- a/stardoc/templates/html_tables/provider.vm
+++ b/stardoc/templates/html_tables/provider.vm
@@ -1,9 +1,18 @@
 <a id="${providerName}"></a>
+#if ($providerInfo.hasInit() && $initParamNamesEqualFieldNames && !$initParamsHaveDistinctDocs && !$initParamsWithInferredDocs.isEmpty())
+#set ($mergeParamsAndFields = true)
+#else
+#set ($mergeParamsAndFields = false)
+#end
 
 #[[##]]# ${providerName}
 
 <pre>
+#if ($providerInfo.hasInit() && !$mergeParamsAndFields)
+${util.providerSummaryWithInitAnchor($providerName, $providerInfo)}
+#else
 ${util.providerSummary($providerName, $providerInfo)}
+#end
 </pre>
 #if (!$providerInfo.docString.isEmpty())
 
@@ -15,7 +24,7 @@ ${providerInfo.docString}
 
 ${providerInfo.init.deprecated.docString}
 #end
-#if ($providerInfo.hasInit() && !$providerInfo.init.parameterList.isEmpty())
+#if ($providerInfo.hasInit() && !$providerInfo.init.parameterList.isEmpty() && !$mergeParamsAndFields)
 
 #[[###]]# Constructor parameters
 
@@ -25,7 +34,7 @@ ${providerInfo.init.deprecated.docString}
 <col class="col-description" />
 </colgroup>
 <tbody>
-#foreach ($param in $providerInfo.init.parameterList)
+#foreach ($param in $initParamsWithInferredDocs)
 <tr id="${providerName}-_init-${param.name}">
 <td><code>${param.name}</code></td>
 <td>
@@ -58,6 +67,28 @@ ${param.docString.trim()}
 <col class="col-description" />
 </colgroup>
 <tbody>
+#if ($mergeParamsAndFields)
+#foreach ($param in $initParamsWithInferredDocs)
+<tr id="${providerName}-_init-${param.name}">
+<td><code>${param.name}</code></td>
+<td>
+
+${util.mandatoryString($param)}.
+#if(!$param.getDefaultValue().isEmpty())
+default is <code>$param.getDefaultValue()</code>
+#end
+
+#if (!$param.docString.isEmpty())
+<p>
+
+${param.docString.trim()}
+
+</p>
+#end
+</td>
+</tr>
+#end
+#else
 #foreach ($field in $providerInfo.fieldInfoList)
 <tr id="${providerName}-${field.name}">
 <td><code>${field.name}</code></td>
@@ -69,6 +100,7 @@ ${field.docString}
 </p>
 </td>
 </tr>
+#end
 #end
 </tbody>
 </table>

--- a/stardoc/templates/markdown_tables/provider.vm
+++ b/stardoc/templates/markdown_tables/provider.vm
@@ -31,7 +31,19 @@ ${providerInfo.init.deprecated.docString}
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 #foreach ($param in $initParamsWithInferredDocs)
-| <a id="${providerName}-_init-${param.name}"></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end  | #if(!$param.getDefaultValue().isEmpty()) ${util.markdownCodeSpan($param.defaultValue)} #else none #end|
+| <a id="${providerName}-_init-${param.name}"></a>$param.name | ##
+#if (!$param.docString.isEmpty())
+${util.markdownCellFormat($param.docString)} ##
+#else
+<p align="center">-</p> ##
+#end
+| ##
+#if (!$param.getDefaultValue().isEmpty())
+${util.markdownCodeSpan($param.defaultValue)} ##
+#else
+none ##
+#end
+|
 #end
 #end
 #if (!$providerInfo.fieldInfoList.isEmpty())
@@ -42,7 +54,21 @@ ${providerInfo.init.deprecated.docString}
 | Name  | Description #if ($initParamsHaveDefaultValues)| Default Value #end|
 | :------------- | :------------- #if ($initParamsHaveDefaultValues)| :------------- |#end|
 #foreach ($param in $initParamsWithInferredDocs)
-| <a id="${providerName}-${param.name}></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end #if ($initParamsHaveDefaultValues)| #if(!$param.getDefaultValue().isEmpty()) ${util.markdownCodeSpan($param.defaultValue)} #else none #end #end|
+| <a id="${providerName}-${param.name}></a>$param.name | ##
+#if (!$param.docString.isEmpty())
+${util.markdownCellFormat($param.docString)} ##
+#else
+<p align="center"> - </p> ##
+#end
+#if($initParamsHaveDefaultValues)
+| ##
+#if (!$param.getDefaultValue().isEmpty())
+${util.markdownCodeSpan($param.defaultValue)} ##
+#else
+none ##
+#end
+#end
+|
 #end
 #else
 | Name  | Description |

--- a/stardoc/templates/markdown_tables/provider.vm
+++ b/stardoc/templates/markdown_tables/provider.vm
@@ -5,12 +5,10 @@
 <pre>
 ${util.providerSummary($providerName, $providerInfo)}
 </pre>
-#if ($providerInfo.hasInit() && !$providerInfo.init.docString.isEmpty())
-
-${providerInfo.init.docString}
-#end
+#if (!$providerInfo.docString.isEmpty())
 
 ${providerInfo.docString}
+#end
 #if ($providerInfo.hasInit() && !$providerInfo.init.deprecated.docString.isEmpty())
 
 **DEPRECATED**

--- a/stardoc/templates/markdown_tables/provider.vm
+++ b/stardoc/templates/markdown_tables/provider.vm
@@ -24,7 +24,7 @@ ${providerInfo.init.deprecated.docString}
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 #foreach ($param in $providerInfo.init.parameterList)
-| <a id="${providerInfo.init.functionName}-_init-${param.name}"></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end  | #if(!$param.getDefaultValue().isEmpty()) ${util.markdownCodeSpan($param.defaultValue)} #else none #end|
+| <a id="${providerName}-_init-${param.name}"></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end  | #if(!$param.getDefaultValue().isEmpty()) ${util.markdownCodeSpan($param.defaultValue)} #else none #end|
 #end
 #end
 

--- a/stardoc/templates/markdown_tables/provider.vm
+++ b/stardoc/templates/markdown_tables/provider.vm
@@ -5,8 +5,28 @@
 <pre>
 ${util.providerSummary($providerName, $providerInfo)}
 </pre>
+#if ($providerInfo.hasInit() && !$providerInfo.init.docString.isEmpty())
+
+${providerInfo.init.docString}
+#end
 
 ${providerInfo.docString}
+#if ($providerInfo.hasInit() && !$providerInfo.init.deprecated.docString.isEmpty())
+
+**DEPRECATED**
+
+${providerInfo.init.deprecated.docString}
+#end
+#if ($providerInfo.hasInit() && !$providerInfo.init.parameterList.isEmpty())
+
+**CONSTRUCTOR PARAMETERS**
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+#foreach ($param in $providerInfo.init.parameterList)
+| <a id="${providerInfo.init.functionName}-_init-${param.name}"></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end  | #if(!$param.getDefaultValue().isEmpty()) ${util.markdownCodeSpan($param.defaultValue)} #else none #end|
+#end
+#end
 
 **FIELDS**
 

--- a/stardoc/templates/markdown_tables/provider.vm
+++ b/stardoc/templates/markdown_tables/provider.vm
@@ -1,9 +1,18 @@
 <a id="${providerName}"></a>
+#if ($providerInfo.hasInit() && $initParamNamesEqualFieldNames && !$initParamsHaveDistinctDocs && !$initParamsWithInferredDocs.isEmpty())
+#set ($mergeParamsAndFields = true)
+#else
+#set ($mergeParamsAndFields = false)
+#end
 
 #[[##]]# ${providerName}
 
 <pre>
+#if ($providerInfo.hasInit() && !$mergeParamsAndFields)
+${util.providerSummaryWithInitAnchor($providerName, $providerInfo)}
+#else
 ${util.providerSummary($providerName, $providerInfo)}
+#end
 </pre>
 #if (!$providerInfo.docString.isEmpty())
 
@@ -15,24 +24,31 @@ ${providerInfo.docString}
 
 ${providerInfo.init.deprecated.docString}
 #end
-#if ($providerInfo.hasInit() && !$providerInfo.init.parameterList.isEmpty())
+#if ($providerInfo.hasInit() && !$providerInfo.init.parameterList.isEmpty() && !$mergeParamsAndFields)
 
 **CONSTRUCTOR PARAMETERS**
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-#foreach ($param in $providerInfo.init.parameterList)
+#foreach ($param in $initParamsWithInferredDocs)
 | <a id="${providerName}-_init-${param.name}"></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end  | #if(!$param.getDefaultValue().isEmpty()) ${util.markdownCodeSpan($param.defaultValue)} #else none #end|
 #end
 #end
+#if (!$providerInfo.fieldInfoList.isEmpty())
 
 **FIELDS**
 
-#if (!$providerInfo.fieldInfoList.isEmpty())
-
+#if ($mergeParamsAndFields)
+| Name  | Description #if ($initParamsHaveDefaultValues)| Default Value #end|
+| :------------- | :------------- #if ($initParamsHaveDefaultValues)| :------------- |#end|
+#foreach ($param in $initParamsWithInferredDocs)
+| <a id="${providerName}-${param.name}></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end #if ($initParamsHaveDefaultValues)| #if(!$param.getDefaultValue().isEmpty()) ${util.markdownCodeSpan($param.defaultValue)} #else none #end #end|
+#end
+#else
 | Name  | Description |
 | :------------- | :------------- |
 #foreach ($field in $providerInfo.fieldInfoList)
 | <a id="${providerName}-${field.name}"></a>$field.name | #if(!$field.docString.isEmpty()) ${util.markdownCellFormat($field.docString)} #else - #end   |
+#end
 #end
 #end

--- a/stardoc/templates/markdown_tables/provider.vm
+++ b/stardoc/templates/markdown_tables/provider.vm
@@ -52,7 +52,7 @@ none ##
 
 #if ($mergeParamsAndFields)
 | Name  | Description #if ($initParamsHaveDefaultValues)| Default Value #end|
-| :------------- | :------------- #if ($initParamsHaveDefaultValues)| :------------- |#end|
+| :------------- | :------------- #if ($initParamsHaveDefaultValues)| :------------- #end|
 #foreach ($param in $initParamsWithInferredDocs)
 | <a id="${providerName}-${param.name}"></a>$param.name | ##
 #if (!$param.docString.isEmpty())

--- a/stardoc/templates/markdown_tables/provider.vm
+++ b/stardoc/templates/markdown_tables/provider.vm
@@ -54,7 +54,7 @@ none ##
 | Name  | Description #if ($initParamsHaveDefaultValues)| Default Value #end|
 | :------------- | :------------- #if ($initParamsHaveDefaultValues)| :------------- |#end|
 #foreach ($param in $initParamsWithInferredDocs)
-| <a id="${providerName}-${param.name}></a>$param.name | ##
+| <a id="${providerName}-${param.name}"></a>$param.name | ##
 #if (!$param.docString.isEmpty())
 ${util.markdownCellFormat($param.docString)} ##
 #else

--- a/test/testdata/angle_bracket_test/golden.md
+++ b/test/testdata/angle_bracket_test/golden.md
@@ -44,7 +44,6 @@ Information with \<brackets>
 
 **FIELDS**
 
-
 | Name  | Description |
 | :------------- | :------------- |
 | <a id="bracketuse-foo"></a>foo |  A string representing \<foo>    |

--- a/test/testdata/misc_apis_test/golden.md
+++ b/test/testdata/misc_apis_test/golden.md
@@ -33,8 +33,6 @@ This rule exercises some of the build API.
 MyInfo(<a href="#MyInfo-foo">foo</a>, <a href="#MyInfo-bar">bar</a>)
 </pre>
 
-
-
 **FIELDS**
 
 

--- a/test/testdata/misc_apis_test/golden.md
+++ b/test/testdata/misc_apis_test/golden.md
@@ -35,7 +35,6 @@ MyInfo(<a href="#MyInfo-foo">foo</a>, <a href="#MyInfo-bar">bar</a>)
 
 **FIELDS**
 
-
 | Name  | Description |
 | :------------- | :------------- |
 | <a id="MyInfo-foo"></a>foo |  Something foo-related.    |

--- a/test/testdata/provider_basic_test/golden.md
+++ b/test/testdata/provider_basic_test/golden.md
@@ -7,52 +7,98 @@
 ## MyCustomInitInfo
 
 <pre>
-MyCustomInitInfo(<a href="#MyCustomInitInfo-_init-foo">foo</a>, <a href="#MyCustomInitInfo-_init-bar">bar</a>)
+MyCustomInitInfo(<a href="#MyCustomInitInfo-foo">foo</a>, <a href="#MyCustomInitInfo-bar">bar</a>)
 </pre>
 
 A provider with a custom constructor.
 
-**CONSTRUCTOR PARAMETERS**
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="MyCustomInitInfo-_init-foo"></a>foo |  Foo data; must be non-negative   |  none |
-| <a id="MyCustomInitInfo-_init-bar"></a>bar |  <p align="center"> - </p>   |  `42` |
+Since the custom constructor parameters match the provider's fields,
+we don't need to render a separate table of constructor parameters.
 
 **FIELDS**
 
-
 | Name  | Description |
 | :------------- | :------------- |
-| <a id="MyCustomInitInfo-foo"></a>foo |  Foo data    |
-| <a id="MyCustomInitInfo-bar"></a>bar |  Bar data. Note that we didn't document `bar` parameter for the init callback - we want this docstring to be propagated to the constructor param table.    |
+| <a id="MyCustomInitInfo-foo></a>foo |  Foo data  |
+| <a id="MyCustomInitInfo-bar></a>bar |  Bar data.  |
 
 
-<a id="MyCustomInitWithExtraFieldInfo"></a>
+<a id="MyCustomInitWithDefaultParamValueInfo"></a>
 
-## MyCustomInitWithExtraFieldInfo
+## MyCustomInitWithDefaultParamValueInfo
 
 <pre>
-MyCustomInitWithExtraFieldInfo(<a href="#MyCustomInitWithExtraFieldInfo-_init-foo">foo</a>, <a href="#MyCustomInitWithExtraFieldInfo-_init-bar">bar</a>)
+MyCustomInitWithDefaultParamValueInfo(<a href="#MyCustomInitWithDefaultParamValueInfo-foo">foo</a>, <a href="#MyCustomInitWithDefaultParamValueInfo-bar">bar</a>)
 </pre>
 
-A provider with a custom constructor.
+A provider with a custom constructor with a parameter with a default value.
+
+Since the custom constructor parameters match the provider's fields,
+we don't need to render a separate table of constructor parameters - but
+we do need to render the default value.
+
+**FIELDS**
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- ||
+| <a id="MyCustomInitWithDefaultParamValueInfo-foo></a>foo |  Foo data  |  none  |
+| <a id="MyCustomInitWithDefaultParamValueInfo-bar></a>bar |  Bar data.  |  `42`  |
+
+
+<a id="MyCustomInitWithDocumentedParamInfo"></a>
+
+## MyCustomInitWithDocumentedParamInfo
+
+<pre>
+MyCustomInitWithDocumentedParamInfo(<a href="#MyCustomInitWithDocumentedParamInfo-_init-foo">foo</a>, <a href="#MyCustomInitWithDocumentedParamInfo-_init-bar">bar</a>)
+</pre>
+
+A provider with a custom constructor with documented constructor parameters.
+
+Docs for constructor parameters differ from docs for fields, so we need to render
+constructor parameters as a separate table.
 
 **CONSTRUCTOR PARAMETERS**
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="MyCustomInitWithExtraFieldInfo-_init-foo"></a>foo |  Foo data; must be non-negative   |  none |
-| <a id="MyCustomInitWithExtraFieldInfo-_init-bar"></a>bar |  <p align="center"> - </p>   |  `42` |
+| <a id="MyCustomInitWithDocumentedParamInfo-_init-foo"></a>foo |  Foo data; must be non-negative   |  none |
+| <a id="MyCustomInitWithDocumentedParamInfo-_init-bar"></a>bar |  Bar data. Note that we didn't document `bar` parameter for the init callback - we want this docstring to be propagated to the constructor param table.   |  `42` |
 
 **FIELDS**
 
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="MyCustomInitWithDocumentedParamInfo-foo"></a>foo |  Foo data    |
+| <a id="MyCustomInitWithDocumentedParamInfo-bar"></a>bar |  Bar data. Note that we didn't document `bar` parameter for the init callback - we want this docstring to be propagated to the constructor param table.    |
+
+
+<a id="MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo"></a>
+
+## MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo
+
+<pre>
+MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo(<a href="#MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo-_init-foo">foo</a>, <a href="#MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo-_init-bar">bar</a>)
+</pre>
+
+A provider with a custom constructor whose set of constructor parameters does not equal the provider's set of fields.
+
+We have no choice - we need to render constructor parameters as a separate table.
+
+**CONSTRUCTOR PARAMETERS**
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo-_init-foo"></a>foo |  Foo data   |  none |
+| <a id="MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo-_init-bar"></a>bar |  Bar data.   |  none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
-| <a id="MyCustomInitWithExtraFieldInfo-foo"></a>foo |  Foo data    |
-| <a id="MyCustomInitWithExtraFieldInfo-bar"></a>bar |  Bar data. Note that we didn't document `bar` parameter for the init callback - we want this docstring to be propagated to the constructor param table.    |
-| <a id="MyCustomInitWithExtraFieldInfo-validated"></a>validated |  Whether the data has been validated    |
+| <a id="MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo-foo"></a>foo |  Foo data    |
+| <a id="MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo-bar"></a>bar |  Bar data.    |
+| <a id="MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo-validated"></a>validated |  True, hopefully    |
 
 
 <a id="MyDeprecatedInfo"></a>
@@ -73,7 +119,6 @@ Do not construct!
 
 **FIELDS**
 
-
 | Name  | Description |
 | :------------- | :------------- |
 | <a id="MyDeprecatedInfo-foo"></a>foo |  Foo    |
@@ -91,7 +136,6 @@ Stores information about a foo.
 
 **FIELDS**
 
-
 | Name  | Description |
 | :------------- | :------------- |
 | <a id="MyFooInfo-bar"></a>bar |  -    |
@@ -105,9 +149,6 @@ Stores information about a foo.
 <pre>
 MyPoorlyDocumentedInfo()
 </pre>
-
-**FIELDS**
-
 
 
 <a id="MyVeryDocumentedInfo"></a>
@@ -123,7 +164,6 @@ A provider with some really neat documentation.
 Look on my works, ye mighty, and despair!
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |

--- a/test/testdata/provider_basic_test/golden.md
+++ b/test/testdata/provider_basic_test/golden.md
@@ -19,8 +19,8 @@ we don't need to render a separate table of constructor parameters.
 
 | Name  | Description |
 | :------------- | :------------- |
-| <a id="MyCustomInitInfo-foo></a>foo | Foo data |
-| <a id="MyCustomInitInfo-bar></a>bar | Bar data. |
+| <a id="MyCustomInitInfo-foo"></a>foo | Foo data |
+| <a id="MyCustomInitInfo-bar"></a>bar | Bar data. |
 
 
 <a id="MyCustomInitWithDefaultParamValueInfo"></a>
@@ -41,8 +41,8 @@ we do need to render the default value.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- ||
-| <a id="MyCustomInitWithDefaultParamValueInfo-foo></a>foo | Foo data | none |
-| <a id="MyCustomInitWithDefaultParamValueInfo-bar></a>bar | Bar data. | `42` |
+| <a id="MyCustomInitWithDefaultParamValueInfo-foo"></a>foo | Foo data | none |
+| <a id="MyCustomInitWithDefaultParamValueInfo-bar"></a>bar | Bar data. | `42` |
 
 
 <a id="MyCustomInitWithDocumentedParamInfo"></a>

--- a/test/testdata/provider_basic_test/golden.md
+++ b/test/testdata/provider_basic_test/golden.md
@@ -2,6 +2,61 @@
 
 
 
+<a id="MyCustomInitInfo"></a>
+
+## MyCustomInitInfo
+
+<pre>
+MyCustomInitInfo(<a href="#MyCustomInitInfo-_init-foo">foo</a>, <a href="#MyCustomInitInfo-_init-bar">bar</a>)
+</pre>
+
+MyCustomInfo constructor.
+
+A provider with a custom constructor.
+
+**CONSTRUCTOR PARAMETERS**
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="MyCustomInitInfo-_init-foo"></a>foo |  Foo data; must be non-negative   |  none |
+| <a id="MyCustomInitInfo-_init-bar"></a>bar |  Bar data   |  `42` |
+
+**FIELDS**
+
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="MyCustomInitInfo-foo"></a>foo |  Foo data    |
+| <a id="MyCustomInitInfo-bar"></a>bar |  Bar data    |
+| <a id="MyCustomInitInfo-validated"></a>validated |  Whether the data has been validated    |
+
+
+<a id="MyDeprecatedInfo"></a>
+
+## MyDeprecatedInfo
+
+<pre>
+MyDeprecatedInfo()
+</pre>
+
+MyDeprecatedInfo constructor.
+
+You can read this info.
+
+But should you really construct it?
+
+**DEPRECATED**
+
+Do not construct!
+
+**FIELDS**
+
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="MyDeprecatedInfo-foo"></a>foo |  Foo    |
+
+
 <a id="MyFooInfo"></a>
 
 ## MyFooInfo

--- a/test/testdata/provider_basic_test/golden.md
+++ b/test/testdata/provider_basic_test/golden.md
@@ -40,7 +40,7 @@ we do need to render the default value.
 **FIELDS**
 
 | Name  | Description | Default Value |
-| :------------- | :------------- | :------------- ||
+| :------------- | :------------- | :------------- |
 | <a id="MyCustomInitWithDefaultParamValueInfo-foo"></a>foo | Foo data | none |
 | <a id="MyCustomInitWithDefaultParamValueInfo-bar"></a>bar | Bar data. | `42` |
 

--- a/test/testdata/provider_basic_test/golden.md
+++ b/test/testdata/provider_basic_test/golden.md
@@ -19,8 +19,8 @@ we don't need to render a separate table of constructor parameters.
 
 | Name  | Description |
 | :------------- | :------------- |
-| <a id="MyCustomInitInfo-foo></a>foo |  Foo data  |
-| <a id="MyCustomInitInfo-bar></a>bar |  Bar data.  |
+| <a id="MyCustomInitInfo-foo></a>foo | Foo data |
+| <a id="MyCustomInitInfo-bar></a>bar | Bar data. |
 
 
 <a id="MyCustomInitWithDefaultParamValueInfo"></a>
@@ -41,8 +41,8 @@ we do need to render the default value.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- ||
-| <a id="MyCustomInitWithDefaultParamValueInfo-foo></a>foo |  Foo data  |  none  |
-| <a id="MyCustomInitWithDefaultParamValueInfo-bar></a>bar |  Bar data.  |  `42`  |
+| <a id="MyCustomInitWithDefaultParamValueInfo-foo></a>foo | Foo data | none |
+| <a id="MyCustomInitWithDefaultParamValueInfo-bar></a>bar | Bar data. | `42` |
 
 
 <a id="MyCustomInitWithDocumentedParamInfo"></a>
@@ -62,8 +62,8 @@ constructor parameters as a separate table.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="MyCustomInitWithDocumentedParamInfo-_init-foo"></a>foo |  Foo data; must be non-negative   |  none |
-| <a id="MyCustomInitWithDocumentedParamInfo-_init-bar"></a>bar |  Bar data. Note that we didn't document `bar` parameter for the init callback - we want this docstring to be propagated to the constructor param table.   |  `42` |
+| <a id="MyCustomInitWithDocumentedParamInfo-_init-foo"></a>foo | Foo data; must be non-negative | none |
+| <a id="MyCustomInitWithDocumentedParamInfo-_init-bar"></a>bar | Bar data. Note that we didn't document `bar` parameter for the init callback - we want this docstring to be propagated to the constructor param table. | `42` |
 
 **FIELDS**
 
@@ -89,8 +89,8 @@ We have no choice - we need to render constructor parameters as a separate table
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo-_init-foo"></a>foo |  Foo data   |  none |
-| <a id="MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo-_init-bar"></a>bar |  Bar data.   |  none |
+| <a id="MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo-_init-foo"></a>foo | Foo data | none |
+| <a id="MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo-_init-bar"></a>bar | Bar data. | none |
 
 **FIELDS**
 

--- a/test/testdata/provider_basic_test/golden.md
+++ b/test/testdata/provider_basic_test/golden.md
@@ -10,8 +10,6 @@
 MyCustomInitInfo(<a href="#MyCustomInitInfo-_init-foo">foo</a>, <a href="#MyCustomInitInfo-_init-bar">bar</a>)
 </pre>
 
-MyCustomInfo constructor.
-
 A provider with a custom constructor.
 
 **CONSTRUCTOR PARAMETERS**
@@ -19,7 +17,7 @@ A provider with a custom constructor.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="MyCustomInitInfo-_init-foo"></a>foo |  Foo data; must be non-negative   |  none |
-| <a id="MyCustomInitInfo-_init-bar"></a>bar |  Bar data   |  `42` |
+| <a id="MyCustomInitInfo-_init-bar"></a>bar |  <p align="center"> - </p>   |  `42` |
 
 **FIELDS**
 
@@ -27,8 +25,34 @@ A provider with a custom constructor.
 | Name  | Description |
 | :------------- | :------------- |
 | <a id="MyCustomInitInfo-foo"></a>foo |  Foo data    |
-| <a id="MyCustomInitInfo-bar"></a>bar |  Bar data    |
-| <a id="MyCustomInitInfo-validated"></a>validated |  Whether the data has been validated    |
+| <a id="MyCustomInitInfo-bar"></a>bar |  Bar data. Note that we didn't document `bar` parameter for the init callback - we want this docstring to be propagated to the constructor param table.    |
+
+
+<a id="MyCustomInitWithExtraFieldInfo"></a>
+
+## MyCustomInitWithExtraFieldInfo
+
+<pre>
+MyCustomInitWithExtraFieldInfo(<a href="#MyCustomInitWithExtraFieldInfo-_init-foo">foo</a>, <a href="#MyCustomInitWithExtraFieldInfo-_init-bar">bar</a>)
+</pre>
+
+A provider with a custom constructor.
+
+**CONSTRUCTOR PARAMETERS**
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="MyCustomInitWithExtraFieldInfo-_init-foo"></a>foo |  Foo data; must be non-negative   |  none |
+| <a id="MyCustomInitWithExtraFieldInfo-_init-bar"></a>bar |  <p align="center"> - </p>   |  `42` |
+
+**FIELDS**
+
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="MyCustomInitWithExtraFieldInfo-foo"></a>foo |  Foo data    |
+| <a id="MyCustomInitWithExtraFieldInfo-bar"></a>bar |  Bar data. Note that we didn't document `bar` parameter for the init callback - we want this docstring to be propagated to the constructor param table.    |
+| <a id="MyCustomInitWithExtraFieldInfo-validated"></a>validated |  Whether the data has been validated    |
 
 
 <a id="MyDeprecatedInfo"></a>
@@ -38,8 +62,6 @@ A provider with a custom constructor.
 <pre>
 MyDeprecatedInfo()
 </pre>
-
-MyDeprecatedInfo constructor.
 
 You can read this info.
 
@@ -83,8 +105,6 @@ Stores information about a foo.
 <pre>
 MyPoorlyDocumentedInfo()
 </pre>
-
-
 
 **FIELDS**
 

--- a/test/testdata/provider_basic_test/input.bzl
+++ b/test/testdata/provider_basic_test/input.bzl
@@ -100,6 +100,7 @@ MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo, _new_my_custom_init_w
     },
 )
 
+# buildifier: disable=function-docstring-args
 def _init_my_custom_init_with_documented_param_info(foo, bar = 42):
     """
     Validate stuff.

--- a/test/testdata/provider_basic_test/input.bzl
+++ b/test/testdata/provider_basic_test/input.bzl
@@ -24,30 +24,54 @@ MyVeryDocumentedInfo = provider(
     },
 )
 
-def _my_custom_info_init(foo, bar = 42):
+def _init_MyCustomInitInfo(foo, bar = 42):
     """
-    MyCustomInfo constructor.
+    Validate stuff.
+
+    Technical details; the user probably doesn't want to see this part.
 
     Args:
         foo: Foo data; must be non-negative
-        bar: Bar data
     """
     if foo < 0:
         fail("foo must be non-negative")
 
     return {"foo": foo, "bar": bar, "validated": True}
 
-MyCustomInitInfo, _new_my_custom_init_info = provider(
+MyCustomInitInfo, _new_MyCustomInitInfo = provider(
     doc = "A provider with a custom constructor.",
-    init = _my_custom_info_init,
+    init = _init_MyCustomInitInfo,
     fields = {
         "foo": "Foo data",
-        "bar": "Bar data",
+        "bar": "Bar data. Note that we didn't document `bar` parameter for the init callback - we want this docstring to be propagated to the constructor param table.",
+    },
+)
+
+def _MyCustomInitWithExtraFieldInfo_init(foo, bar = 42):
+    """
+    Validate stuff.
+
+    Technical details; the user probably doesn't want to see this part.
+
+    Args:
+        foo: Foo data; must be non-negative
+    """
+    if foo < 0:
+        fail("foo must be non-negative")
+
+    return {"foo": foo, "bar": bar}
+
+MyCustomInitWithExtraFieldInfo, _new_MyCustomInitWithExtraFieldInfo = provider(
+    doc = "A provider with a custom constructor.",
+    init = _MyCustomInitWithExtraFieldInfo_init,
+    fields = {
+        "foo": "Foo data",
+        "bar": "Bar data. Note that we didn't document `bar` parameter for the init callback - we want this docstring to be propagated to the constructor param table.",
         "validated": "Whether the data has been validated",
     },
 )
 
-def _my_deprecated_info_init():
+def _init_MyDeprecatedInfo():
     """
     MyDeprecatedInfo constructor.
 
@@ -56,13 +80,13 @@ def _my_deprecated_info_init():
     """
     return {}
 
-MyDeprecatedInfo, _new_my_deprecated_info = provider(
+MyDeprecatedInfo, _new_MyDeprecatedInfo = provider(
     doc = """
     You can read this info.
 
     But should you really construct it?
     """,
-    init = _my_deprecated_info_init,
+    init = _init_MyDeprecatedInfo,
     fields = {
         "foo": "Foo",
     },

--- a/test/testdata/provider_basic_test/input.bzl
+++ b/test/testdata/provider_basic_test/input.bzl
@@ -24,7 +24,7 @@ MyVeryDocumentedInfo = provider(
     },
 )
 
-def _init_MyCustomInitInfo(foo, bar):
+def _init_my_custom_init_info(foo, bar):
     """
     Validate stuff.
 
@@ -35,21 +35,21 @@ def _init_MyCustomInitInfo(foo, bar):
 
     return {"foo": foo, "bar": bar, "validated": True}
 
-MyCustomInitInfo, _new_MyCustomInitInfo = provider(
+MyCustomInitInfo, _new_my_custom_init_info = provider(
     doc = """
     A provider with a custom constructor.
 
     Since the custom constructor parameters match the provider's fields,
     we don't need to render a separate table of constructor parameters.
     """,
-    init = _init_MyCustomInitInfo,
+    init = _init_my_custom_init_info,
     fields = {
         "foo": "Foo data",
         "bar": "Bar data.",
     },
 )
 
-def _init_MyCustomInitWithDefaultParamValueInfo(foo, bar = 42):
+def _init_my_custom_init_with_default_param_value_info(foo, bar = 42):
     """
     Validate stuff.
 
@@ -60,7 +60,7 @@ def _init_MyCustomInitWithDefaultParamValueInfo(foo, bar = 42):
 
     return {"foo": foo, "bar": bar, "validated": True}
 
-MyCustomInitWithDefaultParamValueInfo, _new_MyCustomInitWithDefaultParamValueInfo = provider(
+MyCustomInitWithDefaultParamValueInfo, _new_my_custom_init_with_default_param_value_info = provider(
     doc = """
     A provider with a custom constructor with a parameter with a default value.
 
@@ -68,14 +68,14 @@ MyCustomInitWithDefaultParamValueInfo, _new_MyCustomInitWithDefaultParamValueInf
     we don't need to render a separate table of constructor parameters - but
     we do need to render the default value.
     """,
-    init = _init_MyCustomInitWithDefaultParamValueInfo,
+    init = _init_my_custom_init_with_default_param_value_info,
     fields = {
         "foo": "Foo data",
         "bar": "Bar data.",
     },
 )
 
-def _init_MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo(foo, bar):
+def _init_my_custom_init_with_mismatching_constructor_params_and_fields_info(foo, bar):
     """
     Validate stuff.
 
@@ -86,13 +86,13 @@ def _init_MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo(foo, bar):
 
     return {"foo": foo, "bar": bar, "validated": True}
 
-MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo, _new_MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo = provider(
+MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo, _new_my_custom_init_with_mismatching_constructor_params_and_fields_info = provider(
     doc = """
     A provider with a custom constructor whose set of constructor parameters does not equal the provider's set of fields.
     
     We have no choice - we need to render constructor parameters as a separate table.
     """,
-    init = _init_MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo,
+    init = _init_my_custom_init_with_mismatching_constructor_params_and_fields_info,
     fields = {
         "foo": "Foo data",
         "bar": "Bar data.",
@@ -100,7 +100,7 @@ MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo, _new_MyCustomInitWith
     },
 )
 
-def _MyCustomInitWithDocumentedParamInfo_init(foo, bar = 42):
+def _init_my_custom_init_with_documented_param_info(foo, bar = 42):
     """
     Validate stuff.
 
@@ -114,21 +114,21 @@ def _MyCustomInitWithDocumentedParamInfo_init(foo, bar = 42):
 
     return {"foo": foo, "bar": bar}
 
-MyCustomInitWithDocumentedParamInfo, _new_MyCustomInitWithDocumentedParamInfo = provider(
+MyCustomInitWithDocumentedParamInfo, _new_my_custom_init_with_documented_param_info = provider(
     doc = """
     A provider with a custom constructor with documented constructor parameters.
     
     Docs for constructor parameters differ from docs for fields, so we need to render
     constructor parameters as a separate table.
     """,
-    init = _MyCustomInitWithDocumentedParamInfo_init,
+    init = _init_my_custom_init_with_documented_param_info,
     fields = {
         "foo": "Foo data",
         "bar": "Bar data. Note that we didn't document `bar` parameter for the init callback - we want this docstring to be propagated to the constructor param table.",
     },
 )
 
-def _init_MyDeprecatedInfo():
+def _init_my_deprecated_info():
     """
     MyDeprecatedInfo constructor.
 
@@ -137,13 +137,13 @@ def _init_MyDeprecatedInfo():
     """
     return {}
 
-MyDeprecatedInfo, _new_MyDeprecatedInfo = provider(
+MyDeprecatedInfo, _new_my_deprecated_info = provider(
     doc = """
     You can read this info.
 
     But should you really construct it?
     """,
-    init = _init_MyDeprecatedInfo,
+    init = _init_my_deprecated_info,
     fields = {
         "foo": "Foo",
     },

--- a/test/testdata/provider_basic_test/input.bzl
+++ b/test/testdata/provider_basic_test/input.bzl
@@ -24,14 +24,11 @@ MyVeryDocumentedInfo = provider(
     },
 )
 
-def _init_MyCustomInitInfo(foo, bar = 42):
+def _init_MyCustomInitInfo(foo, bar):
     """
     Validate stuff.
 
     Technical details; the user probably doesn't want to see this part.
-
-    Args:
-        foo: Foo data; must be non-negative
     """
     if foo < 0:
         fail("foo must be non-negative")
@@ -39,15 +36,71 @@ def _init_MyCustomInitInfo(foo, bar = 42):
     return {"foo": foo, "bar": bar, "validated": True}
 
 MyCustomInitInfo, _new_MyCustomInitInfo = provider(
-    doc = "A provider with a custom constructor.",
+    doc = """
+    A provider with a custom constructor.
+
+    Since the custom constructor parameters match the provider's fields,
+    we don't need to render a separate table of constructor parameters.
+    """,
     init = _init_MyCustomInitInfo,
     fields = {
         "foo": "Foo data",
-        "bar": "Bar data. Note that we didn't document `bar` parameter for the init callback - we want this docstring to be propagated to the constructor param table.",
+        "bar": "Bar data.",
     },
 )
 
-def _MyCustomInitWithExtraFieldInfo_init(foo, bar = 42):
+def _init_MyCustomInitWithDefaultParamValueInfo(foo, bar = 42):
+    """
+    Validate stuff.
+
+    Technical details; the user probably doesn't want to see this part.
+    """
+    if foo < 0:
+        fail("foo must be non-negative")
+
+    return {"foo": foo, "bar": bar, "validated": True}
+
+MyCustomInitWithDefaultParamValueInfo, _new_MyCustomInitWithDefaultParamValueInfo = provider(
+    doc = """
+    A provider with a custom constructor with a parameter with a default value.
+
+    Since the custom constructor parameters match the provider's fields,
+    we don't need to render a separate table of constructor parameters - but
+    we do need to render the default value.
+    """,
+    init = _init_MyCustomInitWithDefaultParamValueInfo,
+    fields = {
+        "foo": "Foo data",
+        "bar": "Bar data.",
+    },
+)
+
+def _init_MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo(foo, bar):
+    """
+    Validate stuff.
+
+    Technical details; the user probably doesn't want to see this part.
+    """
+    if foo < 0:
+        fail("foo must be non-negative")
+
+    return {"foo": foo, "bar": bar, "validated": True}
+
+MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo, _new_MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo = provider(
+    doc = """
+    A provider with a custom constructor whose set of constructor parameters does not equal the provider's set of fields.
+    
+    We have no choice - we need to render constructor parameters as a separate table.
+    """,
+    init = _init_MyCustomInitWithMismatchingConstructorParamsAndFieldsInfo,
+    fields = {
+        "foo": "Foo data",
+        "bar": "Bar data.",
+        "validated": "True, hopefully",
+    },
+)
+
+def _MyCustomInitWithDocumentedParamInfo_init(foo, bar = 42):
     """
     Validate stuff.
 
@@ -61,13 +114,17 @@ def _MyCustomInitWithExtraFieldInfo_init(foo, bar = 42):
 
     return {"foo": foo, "bar": bar}
 
-MyCustomInitWithExtraFieldInfo, _new_MyCustomInitWithExtraFieldInfo = provider(
-    doc = "A provider with a custom constructor.",
-    init = _MyCustomInitWithExtraFieldInfo_init,
+MyCustomInitWithDocumentedParamInfo, _new_MyCustomInitWithDocumentedParamInfo = provider(
+    doc = """
+    A provider with a custom constructor with documented constructor parameters.
+    
+    Docs for constructor parameters differ from docs for fields, so we need to render
+    constructor parameters as a separate table.
+    """,
+    init = _MyCustomInitWithDocumentedParamInfo_init,
     fields = {
         "foo": "Foo data",
         "bar": "Bar data. Note that we didn't document `bar` parameter for the init callback - we want this docstring to be propagated to the constructor param table.",
-        "validated": "Whether the data has been validated",
     },
 )
 

--- a/test/testdata/provider_basic_test/input.bzl
+++ b/test/testdata/provider_basic_test/input.bzl
@@ -24,6 +24,50 @@ MyVeryDocumentedInfo = provider(
     },
 )
 
+def _my_custom_info_init(foo, bar = 42):
+    """
+    MyCustomInfo constructor.
+
+    Args:
+        foo: Foo data; must be non-negative
+        bar: Bar data
+    """
+    if foo < 0:
+        fail("foo must be non-negative")
+
+    return {"foo": foo, "bar": bar, "validated": True}
+
+MyCustomInitInfo, _new_my_custom_init_info = provider(
+    doc = "A provider with a custom constructor.",
+    init = _my_custom_info_init,
+    fields = {
+        "foo": "Foo data",
+        "bar": "Bar data",
+        "validated": "Whether the data has been validated",
+    },
+)
+
+def _my_deprecated_info_init():
+    """
+    MyDeprecatedInfo constructor.
+
+    Deprecated:
+        Do not construct!
+    """
+    return {}
+
+MyDeprecatedInfo, _new_my_deprecated_info = provider(
+    doc = """
+    You can read this info.
+
+    But should you really construct it?
+    """,
+    init = _my_deprecated_info_init,
+    fields = {
+        "foo": "Foo",
+    },
+)
+
 named_providers_are_hashable = {
     MyFooInfo: "MyFooInfo is hashable",
     MyVeryDocumentedInfo: "So is MyVeryDocumentedInfo",

--- a/test/testdata/providers_for_attributes_test/golden.md
+++ b/test/testdata/providers_for_attributes_test/golden.md
@@ -34,8 +34,6 @@ This rule does things.
 MyProviderInfo(<a href="#MyProviderInfo-foo">foo</a>, <a href="#MyProviderInfo-bar">bar</a>)
 </pre>
 
-
-
 **FIELDS**
 
 
@@ -52,8 +50,6 @@ MyProviderInfo(<a href="#MyProviderInfo-foo">foo</a>, <a href="#MyProviderInfo-b
 <pre>
 OtherProviderInfo()
 </pre>
-
-
 
 **FIELDS**
 

--- a/test/testdata/providers_for_attributes_test/golden.md
+++ b/test/testdata/providers_for_attributes_test/golden.md
@@ -36,7 +36,6 @@ MyProviderInfo(<a href="#MyProviderInfo-foo">foo</a>, <a href="#MyProviderInfo-b
 
 **FIELDS**
 
-
 | Name  | Description |
 | :------------- | :------------- |
 | <a id="MyProviderInfo-foo"></a>foo |  Something foo-related.    |
@@ -50,9 +49,6 @@ MyProviderInfo(<a href="#MyProviderInfo-foo">foo</a>, <a href="#MyProviderInfo-b
 <pre>
 OtherProviderInfo()
 </pre>
-
-**FIELDS**
-
 
 
 <a id="my_rule_impl"></a>

--- a/test/testdata/pure_markdown_template_test/golden.md
+++ b/test/testdata/pure_markdown_template_test/golden.md
@@ -34,7 +34,6 @@ Small example of provider using a markdown template.
 
 **FIELDS**
 
-
 | Name  | Description |
 | :------------- | :------------- |
 | <a id="ExampleProviderInfo-foo"></a>foo |  A string representing foo    |

--- a/test/testdata/table_of_contents_test/golden.md
+++ b/test/testdata/table_of_contents_test/golden.md
@@ -65,7 +65,6 @@ Stores information about a foo.
 
 **FIELDS**
 
-
 | Name  | Description |
 | :------------- | :------------- |
 | <a id="MyFooInfo-bar"></a>bar |  -    |
@@ -85,7 +84,6 @@ A provider with some really neat documentation.
 Look on my works, ye mighty, and despair!
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |


### PR DESCRIPTION
If a provider has a custom `init` callback, we want the summary blurb to show `init`'s parameters (since these are what the user will interact with); we have to render constructor paramaters and fields separately (and using separate html anchors) since there is not necessarily a 1-1 relationship between them, and since they may have different docs.

Fixes #182