### PR TITLE
Support `*`, `*args`, and `**kwargs` as parameter names in proto input

### DIFF
--- a/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownRenderer.java
+++ b/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownRenderer.java
@@ -192,6 +192,7 @@ public class MarkdownRenderer {
     if (providerInfo.hasInit()) {
       initParamsWithInferredDocs =
           providerInfo.getInit().getParameterList().stream()
+              .filter(param -> !param.getName().equals("*"))
               .map(param -> withInferredDoc(param, fieldDocs))
               .collect(toImmutableList());
     } else {

--- a/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownRenderer.java
+++ b/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownRenderer.java
@@ -201,6 +201,7 @@ public class MarkdownRenderer {
         providerInfo.hasInit()
             && providerInfo.getInit().getParameterList().stream()
                 .map(FunctionParamInfo::getName)
+                .filter(name -> !name.equals("*"))
                 .collect(toImmutableSet())
                 .equals(
                     providerInfo.getFieldInfoList().stream()

--- a/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownUtil.java
+++ b/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownUtil.java
@@ -348,8 +348,15 @@ public final class MarkdownUtil {
       String paramLinksLine =
           params.stream()
               .map(
-                  param ->
-                      String.format("<a href=\"#%s\">%s</a>", paramAnchorNamer.apply(param), param))
+                  param -> {
+                    if (name.equals("*")) {
+                      // Pseudo-parameter dividing positional and keyword-only params.
+                      return "*";
+                    } else {
+                      return String.format(
+                          "<a href=\"#%s\">%s</a>", paramAnchorNamer.apply(unstar(param)), param);
+                    }
+                  })
               .collect(joining(", "));
       paramLinksLines.add(paramLinksLine);
     }
@@ -360,6 +367,17 @@ public final class MarkdownUtil {
 
   private static String summary(String functionName, ImmutableList<String> paramNames) {
     return summary(functionName, paramNames, param -> String.format("%s-%s", functionName, param));
+  }
+
+  /** Removes leading '*' from "**args" and "**kwargs" parameters. */
+  public static String unstar(String paramName) {
+    if (paramName.startsWith("**")) {
+      return paramName.substring(2);
+    } else if (paramName.startsWith("*")) {
+      return paramName.substring(1);
+    } else {
+      return paramName;
+    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownUtil.java
+++ b/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownUtil.java
@@ -369,7 +369,7 @@ public final class MarkdownUtil {
     return summary(functionName, paramNames, param -> String.format("%s-%s", functionName, param));
   }
 
-  /** Removes leading '*' from "**args" and "**kwargs" parameters. */
+  /** Removes leading '*' from "*args" and "**kwargs" parameters. */
   public static String unstar(String paramName) {
     if (paramName.startsWith("**")) {
       return paramName.substring(2);

--- a/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownUtil.java
+++ b/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownUtil.java
@@ -349,8 +349,8 @@ public final class MarkdownUtil {
           params.stream()
               .map(
                   param -> {
-                    if (name.equals("*")) {
-                      // Pseudo-parameter dividing positional and keyword-only params.
+                    if (param.equals("*")) {
+                      // Pseudo-parameter dividing positional and keyword-only params - no link needed.
                       return "*";
                     } else {
                       return String.format(

--- a/stardoc/templates/html_tables/func.vm
+++ b/stardoc/templates/html_tables/func.vm
@@ -18,7 +18,7 @@ ${util.htmlEscape($funcInfo.docString)}
 </colgroup>
 <tbody>
 #foreach ($param in $funcInfo.getParameterList())
-<tr id="${funcInfo.functionName}-${param.name}">
+<tr id="${funcInfo.functionName}-${util.unstar(param.name)}">
 <td><code>${param.name}</code></td>
 <td>
 

--- a/stardoc/templates/html_tables/func.vm
+++ b/stardoc/templates/html_tables/func.vm
@@ -18,7 +18,7 @@ ${util.htmlEscape($funcInfo.docString)}
 </colgroup>
 <tbody>
 #foreach ($param in $funcInfo.getParameterList())
-<tr id="${funcInfo.functionName}-${util.unstar(param.name)}">
+<tr id="${funcInfo.functionName}-${util.unstar($param.name)}">
 <td><code>${param.name}</code></td>
 <td>
 

--- a/stardoc/templates/html_tables/func.vm
+++ b/stardoc/templates/html_tables/func.vm
@@ -18,6 +18,7 @@ ${util.htmlEscape($funcInfo.docString)}
 </colgroup>
 <tbody>
 #foreach ($param in $funcInfo.getParameterList())
+#if (!$param.getName().equals("*"))
 <tr id="${funcInfo.functionName}-${util.unstar($param.name)}">
 <td><code>${param.name}</code></td>
 <td>
@@ -36,6 +37,7 @@ ${param.docString.trim()}
 #end
 </td>
 </tr>
+#end
 #end
 </tbody>
 </table>

--- a/stardoc/templates/html_tables/provider.vm
+++ b/stardoc/templates/html_tables/provider.vm
@@ -35,7 +35,7 @@ ${providerInfo.init.deprecated.docString}
 </colgroup>
 <tbody>
 #foreach ($param in $initParamsWithInferredDocs)
-<tr id="${providerName}-_init-${param.name}">
+<tr id="${providerName}-_init-${util.unstar(param.name)}">
 <td><code>${param.name}</code></td>
 <td>
 

--- a/stardoc/templates/html_tables/provider.vm
+++ b/stardoc/templates/html_tables/provider.vm
@@ -35,7 +35,7 @@ ${providerInfo.init.deprecated.docString}
 </colgroup>
 <tbody>
 #foreach ($param in $initParamsWithInferredDocs)
-<tr id="${providerName}-_init-${util.unstar(param.name)}">
+<tr id="${providerName}-_init-${util.unstar($param.name)}">
 <td><code>${param.name}</code></td>
 <td>
 

--- a/stardoc/templates/markdown_tables/func.vm
+++ b/stardoc/templates/markdown_tables/func.vm
@@ -15,7 +15,7 @@ ${funcInfo.docString}
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 #foreach ($param in $funcInfo.getParameterList())
-| <a id="${funcInfo.functionName}-${param.name}"></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end  | #if(!$param.getDefaultValue().isEmpty()) ${util.markdownCodeSpan($param.defaultValue)} #else none #end|
+| <a id="${funcInfo.functionName}-${util.unstar(param.name)}"></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end  | #if(!$param.getDefaultValue().isEmpty()) ${util.markdownCodeSpan($param.defaultValue)} #else none #end|
 #end
 #end
 #if (!$funcInfo.getReturn().docString.isEmpty())

--- a/stardoc/templates/markdown_tables/func.vm
+++ b/stardoc/templates/markdown_tables/func.vm
@@ -15,7 +15,7 @@ ${funcInfo.docString}
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 #foreach ($param in $funcInfo.getParameterList())
-| <a id="${funcInfo.functionName}-${util.unstar(param.name)}"></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end  | #if(!$param.getDefaultValue().isEmpty()) ${util.markdownCodeSpan($param.defaultValue)} #else none #end|
+| <a id="${funcInfo.functionName}-${util.unstar($param.name)}"></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end  | #if(!$param.getDefaultValue().isEmpty()) ${util.markdownCodeSpan($param.defaultValue)} #else none #end|
 #end
 #end
 #if (!$funcInfo.getReturn().docString.isEmpty())

--- a/stardoc/templates/markdown_tables/func.vm
+++ b/stardoc/templates/markdown_tables/func.vm
@@ -15,7 +15,9 @@ ${funcInfo.docString}
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 #foreach ($param in $funcInfo.getParameterList())
+#if (!$param.getName().equals("*"))
 | <a id="${funcInfo.functionName}-${util.unstar($param.name)}"></a>$param.name | #if(!$param.docString.isEmpty()) ${util.markdownCellFormat($param.docString)} #else <p align="center"> - </p> #end  | #if(!$param.getDefaultValue().isEmpty()) ${util.markdownCodeSpan($param.defaultValue)} #else none #end|
+#end
 #end
 #end
 #if (!$funcInfo.getReturn().docString.isEmpty())

--- a/stardoc/templates/markdown_tables/provider.vm
+++ b/stardoc/templates/markdown_tables/provider.vm
@@ -31,7 +31,7 @@ ${providerInfo.init.deprecated.docString}
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 #foreach ($param in $initParamsWithInferredDocs)
-| <a id="${providerName}-_init-${param.name}"></a>$param.name | ##
+| <a id="${providerName}-_init-${util.unstar(param.name)}"></a>$param.name | ##
 #if (!$param.docString.isEmpty())
 ${util.markdownCellFormat($param.docString)} ##
 #else

--- a/stardoc/templates/markdown_tables/provider.vm
+++ b/stardoc/templates/markdown_tables/provider.vm
@@ -31,7 +31,7 @@ ${providerInfo.init.deprecated.docString}
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 #foreach ($param in $initParamsWithInferredDocs)
-| <a id="${providerName}-_init-${util.unstar(param.name)}"></a>$param.name | ##
+| <a id="${providerName}-_init-${util.unstar($param.name)}"></a>$param.name | ##
 #if (!$param.docString.isEmpty())
 ${util.markdownCellFormat($param.docString)} ##
 #else


### PR DESCRIPTION
Requires Bazel support to generate function info protos with such parameter names, though.

Working towards https://github.com/bazelbuild/stardoc/issues/226