### PR TITLE
proto_format_test requires Bazel 7.1, and may break with other Bazel releases

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -90,4 +90,13 @@ tasks:
     platform: windows
     working_directory: test/bzlmod
 
+  bazel_7_1_tests:
+    name: Stardoc golden tests requiring Bazel 7.1
+    platform: ubuntu2004
+    bazel: 7.1.x
+    build_flags: *common_flags
+    test_flags: *common_flags
+    test_targets:
+    - "//test:proto_format_test"
+
 buildifier: latest

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -97,6 +97,6 @@ tasks:
     build_flags: *common_flags
     test_flags: *common_flags
     test_targets:
-    - "//test:proto_format_test"
+    - "//test:proto_format_test_e2e_test"
 
 buildifier: latest

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -93,7 +93,7 @@ tasks:
   bazel_7_1_tests:
     name: Stardoc golden tests requiring Bazel 7.1
     platform: ubuntu2004
-    bazel: 7.1.x
+    bazel: 7.1.2
     build_flags: *common_flags
     test_flags: *common_flags
     test_targets:

--- a/test/BUILD
+++ b/test/BUILD
@@ -2,7 +2,10 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load(":stardoc_test.bzl", "self_gen_test", "stardoc_test")
 
-package(default_applicable_licenses = ["//:license"])
+package(
+    default_applicable_licenses = ["//:license"],
+    default_testonly = True,
+)
 
 licenses(["notice"])  # Apache 2.0
 
@@ -36,6 +39,8 @@ stardoc_test(
     format = "proto",
     golden_file = "testdata/proto_format_test/golden.binaryproto",
     input_file = "testdata/proto_format_test/input.bzl",
+    # Golden output was generated with Bazel 7.1 and may differ in other versions
+    tags = ["manual", "bazel_7_1"],
 )
 
 stardoc_test(

--- a/test/BUILD
+++ b/test/BUILD
@@ -40,7 +40,10 @@ stardoc_test(
     golden_file = "testdata/proto_format_test/golden.binaryproto",
     input_file = "testdata/proto_format_test/input.bzl",
     # Golden output was generated with Bazel 7.1 and may differ in other versions
-    tags = ["manual", "bazel_7_1"],
+    tags = [
+        "bazel_7_1",
+        "manual",
+    ],
 )
 
 stardoc_test(

--- a/test/stardoc_test.bzl
+++ b/test/stardoc_test.bzl
@@ -82,6 +82,7 @@ def _create_test_targets(
             actual_generated_doc,
             golden_file,
         ],
+        tags = kwargs.get("tags", []),
     )
 
     if test == "default":

--- a/update-stardoc-tests.sh
+++ b/update-stardoc-tests.sh
@@ -36,7 +36,7 @@ function run_buildozer () {
 : "${BAZEL:=bazel}"
 
 # Some tests cannot be automatically regenerated using this script, as they don't fall under the normal
-# golden test pattern
+# golden test pattern or require a specific Bazel version
 EXCLUDED_TESTS="namespace_test_with_allowlist|multi_level_namespace_test_with_allowlist|local_repository_test|stamping_with_stamping_off"
 echo "** Querying for tests..."
 regen_targets=$(${BAZEL} query //test:all | grep regenerate_ | grep -vE "_golden\.extract|$EXCLUDED_TESTS")


### PR DESCRIPTION
Fixes #228