### PR TITLE
Improve incompatible flag testing

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -5,25 +5,30 @@ matrix:
     - ubuntu2004
     - macos
 
-.common_flags: &common_flags
-  ? "--incompatible_disable_starlark_host_transitions"
+.incompatible_flags: &incompatible_flags
+  ? "--config=incompatible"
 
 .noenable_bzlmod_flags: &noenable_bzlmod_flags
-  <<: *common_flags
+  ? "--noenable_bzlmod"
+
+.incompatible_noenable_bzlmod_flags: &incompatible_noenable_bzlmod_flags
+  ? "--config=incompatible"
   ? "--noenable_bzlmod"
 
 .windows_flags: &windows_flags
-  <<: *common_flags
   # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012
   ? "--noexperimental_repository_cache_hardlinks"
 
 .common_task_config: &common_task_config
-  build_flags: *common_flags
   build_targets:
     - "//..."
-  test_flags: *common_flags
   test_targets:
     - "//..."
+
+.incompatible_task_config: &incompatible_task_config
+  <<: *common_task_config
+  build_flags: *incompatible_flags
+  test_flags: *incompatible_flags
 
 .noenable_bzlmod_task_config: &noenable_bzlmod_task_config
   build_flags: *noenable_bzlmod_flags
@@ -41,6 +46,11 @@ matrix:
     - "//test:table_of_contents_noenable_bzlmod_test"
     - "//test:local_repository_test"
 
+.incompatible_noenable_bzlmod_task_config: &incompatible_noenable_bzlmod_task_config
+  <<: *noenable_bzlmod_task_config
+  build_flags: *incompatible_noenable_bzlmod_flags
+  test_flags: *incompatible_noenable_bzlmod_flags
+
 .windows_task_config: &windows_task_config
   <<: *common_task_config
   build_flags: *windows_flags
@@ -52,6 +62,11 @@ tasks:
     name: Build and test
     platform: ${{ platform }}
 
+  build_and_test_incompatible:
+    <<: *incompatible_task_config
+    name: Build and test - incompatible flags
+    platform: ${{ platform }}
+
   build_and_test_windows:
     <<: *windows_task_config
     name: Build and test - Windows
@@ -60,6 +75,11 @@ tasks:
   noenable_bzlmod:
     <<: *noenable_bzlmod_task_config
     name: Build and test - legacy WORKSPACE setup
+    platform: ${{ platform }}
+
+  incompatible_noenable_bzlmod:
+    <<: *incompatible_noenable_bzlmod_task_config
+    name: Build and test - legacy WORKSPACE setup with incompatible flags
     platform: ${{ platform }}
 
   build_and_test_last_green:
@@ -80,6 +100,12 @@ tasks:
     platform: ${{ platform }}
     working_directory: test/bzlmod
 
+  bzlmod_usage_incompatible:
+    <<: *incompatible_task_config
+    name: Stardoc Bzlmod module usage test - incompatible flags
+    platform: ${{ platform }}
+    working_directory: test/bzlmod
+
   bzlmod_usage_windows:
     <<: *windows_task_config
     name: Stardoc Bzlmod module usage test - Windows
@@ -90,8 +116,6 @@ tasks:
     name: Stardoc golden tests requiring Bazel 7.2
     platform: ubuntu2004
     bazel: 7.2.0
-    build_flags: *common_flags
-    test_flags: *common_flags
     test_targets:
     - "//test:proto_format_test"
     - "//test:macro_kwargs_legacy_test"
@@ -100,8 +124,6 @@ tasks:
     name: Stardoc golden tests requiring Bazel HEAD
     platform: ubuntu2004
     bazel: last_green
-    build_flags: *common_flags
-    test_flags: *common_flags
     test_targets:
     - "//test:macro_kwargs_test"
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,9 @@
 build --java_language_version=11
 build --tool_java_language_version=11
+
+# Incompatible flags which we always want in development
+build --incompatible_disable_starlark_host_transitions
+build --incompatible_disallow_empty_glob
+
+# Incompatible flags to test in a dedicated CI pipeline.
+build:incompatible --incompatible_enable_proto_toolchain_resolution

--- a/BUILD
+++ b/BUILD
@@ -52,12 +52,3 @@ filegroup(
     ] + glob(["*.bzl"]),
     visibility = ["//:__subpackages__"],
 )
-
-# Binaries needed for release tarball.
-filegroup(
-    name = "distro_bins",
-    srcs = [
-        "//stardoc:distro_bins",
-    ],
-    visibility = ["//:__subpackages__"],
-)

--- a/distro/BUILD
+++ b/distro/BUILD
@@ -30,8 +30,10 @@ strip_internal_only(
     out = "WORKSPACE.bzlmod",
 )
 
+# Build the artifact to put on the github release page.
 pkg_tar(
-    name = "distro_srcs",
+    name = "stardoc-%s" % version,
+    extension = "tar.gz",
     srcs = [
         "distro_module_bazel",
         "distro_workspace",
@@ -43,27 +45,4 @@ pkg_tar(
     owner = "0.0",
     package_dir = "",
     strip_prefix = ".",
-)
-
-pkg_tar(
-    name = "distro_bins",
-    srcs = ["//:distro_bins"],
-    mode = "0755",
-    # Make it owned by root so it does not have the uid of the CI robot.
-    owner = "0.0",
-    package_dir = "",
-    strip_prefix = ".",
-)
-
-# Build the artifact to put on the github release page.
-pkg_tar(
-    name = "stardoc-%s" % version,
-    extension = "tar.gz",
-    # Make it owned by root so it does not have the uid of the CI robot.
-    owner = "0.0",
-    strip_prefix = ".",
-    deps = [
-        ":distro_bins.tar",
-        ":distro_srcs.tar",
-    ],
 )

--- a/distro/BUILD
+++ b/distro/BUILD
@@ -33,13 +33,13 @@ strip_internal_only(
 # Build the artifact to put on the github release page.
 pkg_tar(
     name = "stardoc-%s" % version,
-    extension = "tar.gz",
     srcs = [
         "distro_module_bazel",
         "distro_workspace",
         "distro_workspace_bzlmod",
         "//:distro_srcs",
     ],
+    extension = "tar.gz",
     mode = "0644",
     # Make it owned by root so it does not have the uid of the CI robot.
     owner = "0.0",

--- a/stardoc/BUILD
+++ b/stardoc/BUILD
@@ -65,10 +65,3 @@ filegroup(
     ]),
     visibility = ["//:__pkg__"],
 )
-
-# Binaries needed for release tarball.
-filegroup(
-    name = "distro_bins",
-    srcs = glob(["*.jar"]),
-    visibility = ["//:__pkg__"],
-)

--- a/test/bzlmod/.bazelrc
+++ b/test/bzlmod/.bazelrc
@@ -1,1 +1,10 @@
 common --enable_bzlmod
+build --java_language_version=11
+build --tool_java_language_version=11
+
+# Incompatible flags which we always want in development
+build --incompatible_disable_starlark_host_transitions
+build --incompatible_disallow_empty_glob
+
+# Incompatible flags to test in a dedicated CI pipeline.
+build:incompatible --incompatible_enable_proto_toolchain_resolution


### PR DESCRIPTION
We always want to use some flags in development; e.g. an empty glob is a sign of a mistake, so we always want --incompatible_disallow_empty_glob

We will unconditionally set such flags in .bazelrc (not just in CI config).

For other incompatible flags (--incompatible_enable_proto_toolchain_resolution), we want to test builds both with and without them - and with bzlmod both enabled and disabled (see discussion in #236 for a case where this matters).

Such flags we will group under --config=incompatible, and test all 4 combinations (+- incompatible +- bzlmod) in CI.