### PR TITLE
Merge user-defined tags with default tags in stardoc macro

### DIFF
--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -94,7 +94,7 @@ def stardoc(
 
     if "tags" in kwargs:
         # Merge the user-provided tags with the default tags
-        auxiliary_target_kwargs["tags"] += kwargs["tags"]    
+        auxiliary_target_kwargs["tags"] += kwargs["tags"]
 
     if format == "proto" and Label(name + ".binaryproto") == Label(out):
         extractor_is_main_target = True

--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -92,6 +92,10 @@ def stardoc(
     if "testonly" in kwargs:
         auxiliary_target_kwargs["testonly"] = kwargs["testonly"]
 
+    if "tags" in kwargs:
+        # Merge the user-provided tags with the default tags
+        auxiliary_target_kwargs["tags"] += kwargs["tags"]    
+
     if format == "proto" and Label(name + ".binaryproto") == Label(out):
         extractor_is_main_target = True
         extractor_name = name

--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -93,10 +93,11 @@ def stardoc(
         auxiliary_target_kwargs["testonly"] = kwargs["testonly"]
 
     if "tags" in kwargs:
-        # we use a set to merge the tags and avoid duplicates
-        user_tags = set(kwargs["tags"])
-        auxiliary_target_kwargs["tags"].update(user_tags)
-        auxiliary_target_kwargs["tags"] = list(auxiliary_target_kwargs["tags"])
+        user_tags = kwargs["tags"]
+        if "manual" not in user_tags:
+            auxiliary_target_kwargs["tags"] += user_tags
+        else:
+            auxiliary_target_kwargs["tags"] = user_tags
 
     if format == "proto" and Label(name + ".binaryproto") == Label(out):
         extractor_is_main_target = True

--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -94,10 +94,9 @@ def stardoc(
 
     if "tags" in kwargs:
         user_tags = kwargs["tags"]
-        if "manual" not in user_tags:
-            auxiliary_target_kwargs["tags"] += user_tags
-        else:
-            auxiliary_target_kwargs["tags"] = user_tags
+
+        # Merge tags from kwargs without duplicating "manual"
+        auxiliary_target_kwargs["tags"] += [tag for tag in user_tags if tag not in auxiliary_target_kwargs["tags"]]
 
     if format == "proto" and Label(name + ".binaryproto") == Label(out):
         extractor_is_main_target = True

--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -93,11 +93,10 @@ def stardoc(
         auxiliary_target_kwargs["testonly"] = kwargs["testonly"]
 
     if "tags" in kwargs:
-        # Merge the user-provided tags with the default tags, avoiding duplicates
-        user_tags = kwargs["tags"]
-        for tag in user_tags:
-            if tag not in auxiliary_target_kwargs["tags"]:
-                auxiliary_target_kwargs["tags"].append(tag)
+        # we use a set to merge the tags and avoid duplicates
+        user_tags = set(kwargs["tags"])
+        auxiliary_target_kwargs["tags"].update(user_tags)
+        auxiliary_target_kwargs["tags"] = list(auxiliary_target_kwargs["tags"])
 
     if format == "proto" and Label(name + ".binaryproto") == Label(out):
         extractor_is_main_target = True

--- a/stardoc/stardoc.bzl
+++ b/stardoc/stardoc.bzl
@@ -93,8 +93,11 @@ def stardoc(
         auxiliary_target_kwargs["testonly"] = kwargs["testonly"]
 
     if "tags" in kwargs:
-        # Merge the user-provided tags with the default tags
-        auxiliary_target_kwargs["tags"] += kwargs["tags"]
+        # Merge the user-provided tags with the default tags, avoiding duplicates
+        user_tags = kwargs["tags"]
+        for tag in user_tags:
+            if tag not in auxiliary_target_kwargs["tags"]:
+                auxiliary_target_kwargs["tags"].append(tag)
 
     if format == "proto" and Label(name + ".binaryproto") == Label(out):
         extractor_is_main_target = True


### PR DESCRIPTION
### Description

This pull request introduces changes to the `stardoc` macro to enhance its functionality by including user-defined tags in auxiliary targets. Previously, auxiliary targets only included default tags, and there was no way to specify additional tags.

### Changes Made

1. **Tag Handling:**
   - **Update:** Modified the `stardoc` macro to merge user-defined tags with default tags for auxiliary targets.
   - **Default Behavior:** By default, auxiliary targets receive the `["manual"]` tag.
   - **User-defined Tags:** If user-defined tags are provided, they are appended to the default tag list.

2. **Code Modifications:**
   - **File Updated:** `stardoc/stardoc.bzl`
   - **Details:** Added logic to handle the merging of tags in the `stardoc` macro. Ensured that user-defined tags are correctly 
     combined with default tags before being applied to auxiliary targets.
     
Fixes #245 
