### PR TITLE
Fix CI since --enable_workspace is now disabled by default in Bazel HEAD

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -7,6 +7,7 @@ matrix:
 
 .noenable_bzlmod_flags: &noenable_bzlmod_flags
   ? "--noenable_bzlmod"
+  ? "--enable_workspace"
 
 .windows_flags: &windows_flags
   # Workaround for https://github.com/bazelbuild/continuous-integration/issues/1012

--- a/test/BUILD
+++ b/test/BUILD
@@ -373,6 +373,10 @@ sh_test(
         "@local_repository_test//:golden.md",
         "@local_repository_test//:output.md",
     ],
+    tags = [
+        "manual",
+        "noenable_bzlmod",
+    ],
 )
 
 # Consistency tests for WORKSPACE-related .bzl files vs. MODULE.bazel


### PR DESCRIPTION
This means we need to enable workspace explicitly for legacy workspace tests - and mark local_repository_test as a legacy workspace test.

Fixes https://github.com/bazelbuild/stardoc/issues/250