### PR TITLE
Fix `//stardoc:distro_bins` empty glob

### DIFF
--- a/stardoc/BUILD
+++ b/stardoc/BUILD
@@ -85,6 +85,9 @@ filegroup(
 # Binaries needed for release tarball.
 filegroup(
     name = "distro_bins",
-    srcs = glob(["*.jar"]),
+    srcs = glob(
+        ["*.jar"],
+        allow_empty = True,
+    ),
     visibility = ["//:__pkg__"],
 )


### PR DESCRIPTION
For a ruleset like rules_apple that still supports Bazel 6, fix support on pre-`0.7.0` releases by strictly allowing an empty glob on the `//stardoc:distro_bins` to fix an issue like https://github.com/bazelbuild/rules_apple/issues/2555.

This is opened with the intent of creating a 0.6.3 release that has better support for Bazel 6, 7, and 8 simultaneously.