### PR TITLE
Replace AppleDynamicFramework in test/testdata/apple_basic_test

### DIFF
--- a/test/testdata/apple_basic_test/input.bzl
+++ b/test/testdata/apple_basic_test/input.bzl
@@ -2,7 +2,7 @@
 # buildifier: disable=function-docstring
 def exercise_the_api():
     var1 = apple_common.platform_type  # @unused
-    var2 = apple_common.AppleDynamicFramework  # @unused
+    var2 = apple_common.XcodeVersionConfig  # @unused
 
 exercise_the_api()
 


### PR DESCRIPTION
Replace apple_common.AppleDynamicFramework in test/testdata/apple_basic_test with
apple_common.XcodeVersionConfig before apple_common.AppleDynamicFramework gets removed
