### PR TITLE
fix: add missing proto_library load to support Bazel 8

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,7 +1,6 @@
 ---
 matrix:
   platform:
-    - ubuntu1804
     - ubuntu2004
     - macos
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,6 @@
-build --java_language_version=11
-build --tool_java_language_version=11
+# Prevent build failure if jdk > 21 is installed as the default system jdk
+# See https://github.com/bazelbuild/stardoc/pull/263#issuecomment-2502032361
+build --java_runtime_version=21
 
 # Incompatible flags which we always want in development
 build --incompatible_disable_starlark_host_transitions

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,11 +5,11 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "protobuf", version = "29.0-rc2", repo_name = "com_google_protobuf")
-bazel_dep(name = "bazel_skylib", version = "1.6.1")
-bazel_dep(name = "rules_java", version = "7.6.1")
-bazel_dep(name = "rules_jvm_external", version = "6.1")
-bazel_dep(name = "rules_license", version = "0.0.7")
+bazel_dep(name = "protobuf", version = "29.0-rc3", repo_name = "com_google_protobuf")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_java", version = "8.5.1")
+bazel_dep(name = "rules_jvm_external", version = "6.3")
+bazel_dep(name = "rules_license", version = "1.0.0")
 
 # Maven artifacts required by Stardoc; keep consistent with deps.bzl
 STARDOC_MAVEN_ARTIFACTS = [
@@ -36,4 +36,4 @@ use_repo(maven, "stardoc_maven")
 ### INTERNAL ONLY - lines after this are not included in the release packaging.
 #
 # Dev-only and test-only dependencies
-bazel_dep(name = "rules_pkg", version = "0.10.1", dev_dependency = True)
+bazel_dep(name = "rules_pkg", version = "1.0.1", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "protobuf", version = "29.0-rc2", repo_name = "com_google_protobuf")
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
 bazel_dep(name = "rules_java", version = "7.6.1")
 bazel_dep(name = "rules_jvm_external", version = "6.1")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,6 +5,14 @@ load(":setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
 
+load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
+
+rules_java_dependencies()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
 load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
 
 rules_jvm_external_deps()
@@ -57,9 +65,10 @@ bind(
 # Needed for //distro:__pkg__
 http_archive(
     name = "rules_pkg",
-    sha256 = "d250924a2ecc5176808fc4c25d5cf5e9e79e6346d79d5ab1c493e289e722d1d0",
+    sha256 = "d20c951960ed77cb7b341c2a59488534e494d5ad1d30c4818c736d57772a9fef",
     urls = [
-        "https://github.com/bazelbuild/rules_pkg/releases/download/0.10.1/rules_pkg-0.10.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz",
     ],
 )
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -15,10 +15,10 @@
 """WORKSPACE dependency definitions for Stardoc."""
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
+load("@rules_python//python:repositories.bzl", "py_repositories")
 
 # Maven artifacts required by Stardoc; keep consistent with MODULE.bazel
 STARDOC_MAVEN_ARTIFACTS = [
@@ -53,6 +53,8 @@ def stardoc_external_deps():
         ],
         strict_visibility = True,
     )
+
+    py_repositories()
 
     rules_proto_dependencies()
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -14,7 +14,6 @@
 
 """WORKSPACE dependency definitions for Stardoc."""
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 load("@rules_proto//proto:setup.bzl", "rules_proto_setup")

--- a/deps.bzl
+++ b/deps.bzl
@@ -15,6 +15,7 @@
 """WORKSPACE dependency definitions for Stardoc."""
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
@@ -52,8 +53,6 @@ def stardoc_external_deps():
         ],
         strict_visibility = True,
     )
-
-    protobuf_deps()
 
     rules_proto_dependencies()
 

--- a/docs/maintainers_guide.md
+++ b/docs/maintainers_guide.md
@@ -95,6 +95,14 @@ load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
 
+load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
+
+rules_java_dependencies()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
 load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
 
 rules_jvm_external_deps()

--- a/setup.bzl
+++ b/setup.bzl
@@ -117,10 +117,17 @@ def stardoc_repositories():
         url = "https://github.com/bazelbuild/rules_python/releases/download/0.20.0/rules_python-0.20.0.tar.gz",
     )
 
+    ##maybe(
+    ##    http_archive,
+    ##    name = "rules_cc",
+    ##    sha256 = "4b12149a041ddfb8306a8fd0e904e39d673552ce82e4296e96fac9cbf0780e59",
+    ##    strip_prefix = "rules_cc-0.1.0",
+    ##    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.0/rules_cc-0.1.0.tar.gz"],
+    ##)
     maybe(
         http_archive,
         name = "rules_cc",
-        sha256 = "4b12149a041ddfb8306a8fd0e904e39d673552ce82e4296e96fac9cbf0780e59",
-        strip_prefix = "rules_cc-0.1.0",
-        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.0/rules_cc-0.1.0.tar.gz"],
+        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.17/rules_cc-0.0.17.tar.gz"],
+        sha256 = "abc605dd850f813bb37004b77db20106a19311a96b2da1c92b789da529d28fe1",
+        strip_prefix = "rules_cc-0.0.17",
     )

--- a/setup.bzl
+++ b/setup.bzl
@@ -29,15 +29,23 @@ def stardoc_repositories():
         ],
     )
 
+    ##maybe(
+    ##    http_archive,
+    ##    name = "com_google_protobuf",
+    ##    sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
+    ##    strip_prefix = "protobuf-21.7",
+    ##    urls = [
+    ##        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
+    ##        "https://github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
+    ##    ],
+    ##)
+
     maybe(
         http_archive,
         name = "com_google_protobuf",
-        sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
-        strip_prefix = "protobuf-21.7",
-        urls = [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
-            "https://github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
-        ],
+        sha256 = "23082dca1ca73a1e9c6cbe40097b41e81f71f3b4d6201e36c134acc30a1b3660",
+        url = "https://github.com/protocolbuffers/protobuf/releases/download/v29.0-rc2/protobuf-29.0-rc2.zip",
+        strip_prefix = "protobuf-29.0-rc2",
     )
 
     maybe(

--- a/setup.bzl
+++ b/setup.bzl
@@ -116,3 +116,11 @@ def stardoc_repositories():
         strip_prefix = "rules_python-0.20.0",
         url = "https://github.com/bazelbuild/rules_python/releases/download/0.20.0/rules_python-0.20.0.tar.gz",
     )
+
+    maybe(
+        http_archive,
+        name = "rules_cc",
+        sha256 = "4b12149a041ddfb8306a8fd0e904e39d673552ce82e4296e96fac9cbf0780e59",
+        strip_prefix = "rules_cc-0.1.0",
+        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.0/rules_cc-0.1.0.tar.gz"],
+    )

--- a/setup.bzl
+++ b/setup.bzl
@@ -48,14 +48,22 @@ def stardoc_repositories():
         strip_prefix = "protobuf-29.0-rc2",
     )
 
+    ##maybe(
+    ##    http_archive,
+    ##    name = "rules_java",
+    ##    urls = [
+    ##        "https://mirror.bazel.build/github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz",
+    ##        "https://github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz",
+    ##    ],
+    ##    sha256 = "f8ae9ed3887df02f40de9f4f7ac3873e6dd7a471f9cddf63952538b94b59aeb3",
+    ##)
     maybe(
         http_archive,
         name = "rules_java",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz",
-            "https://github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz",
+            "https://github.com/bazelbuild/rules_java/releases/download/8.0.0-rc1/rules_java-8.0.0-rc1.tar.gz",
         ],
-        sha256 = "f8ae9ed3887df02f40de9f4f7ac3873e6dd7a471f9cddf63952538b94b59aeb3",
+        sha256 = "b2441c2afdc3b79fba75721c5c5ccbca947f15cc7f107c033efa18845933f975",
     )
 
     RULES_JVM_EXTERNAL_TAG = "6.1"

--- a/setup.bzl
+++ b/setup.bzl
@@ -28,55 +28,27 @@ def stardoc_repositories():
             "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
         ],
     )
-    ##maybe(
-    ##    http_archive,
-    ##    name = "bazel_skylib",
-    ##    sha256 = "9f38886a40548c6e96c106b752f242130ee11aaa068a56ba7e56f4511f33e4f2",
-    ##    urls = [
-    ##        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz",
-    ##        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz",
-    ##    ],
-    ##)
-
-    ##maybe(
-    ##    http_archive,
-    ##    name = "com_google_protobuf",
-    ##    sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
-    ##    strip_prefix = "protobuf-21.7",
-    ##    urls = [
-    ##        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
-    ##        "https://github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
-    ##    ],
-    ##)
 
     maybe(
         http_archive,
         name = "com_google_protobuf",
-        sha256 = "23082dca1ca73a1e9c6cbe40097b41e81f71f3b4d6201e36c134acc30a1b3660",
-        url = "https://github.com/protocolbuffers/protobuf/releases/download/v29.0-rc2/protobuf-29.0-rc2.zip",
-        strip_prefix = "protobuf-29.0-rc2",
+        sha256 = "537d1c4edb6cbfa96d98a021650e3c455fffcf80dbdcea7fe46cb356e6e9732d",
+        strip_prefix = "protobuf-29.0-rc3",
+        urls = [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/releases/download/v29.0-rc3/protobuf-29.0-rc3.zip",
+            "https://github.com/protocolbuffers/protobuf/releases/download/v29.0-rc3/protobuf-29.0-rc3.zip",
+        ],
     )
 
-    ##maybe(
-    ##    http_archive,
-    ##    name = "rules_java",
-    ##    urls = [
-    ##        "https://mirror.bazel.build/github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz",
-    ##        "https://github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz",
-    ##    ],
-    ##    sha256 = "f8ae9ed3887df02f40de9f4f7ac3873e6dd7a471f9cddf63952538b94b59aeb3",
-    ##)
     maybe(
         http_archive,
         name = "rules_java",
-        urls = [
-            "https://github.com/bazelbuild/rules_java/releases/download/7.12.1/rules_java-7.12.1.tar.gz",
-        ],
-        sha256 = "dfbadbb37a79eb9e1cc1e156ecb8f817edf3899b28bc02410a6c1eb88b1a6862",
+        sha256 = "1389206b2208c5f33a05dd96e51715b0855c480c082b7bb4889a8e07fcff536c",
+        url = "https://github.com/bazelbuild/rules_java/releases/download/8.5.1/rules_java-8.5.1.tar.gz",
     )
 
-    RULES_JVM_EXTERNAL_TAG = "6.1"
-    RULES_JVM_EXTERNAL_SHA = "08ea921df02ffe9924123b0686dc04fd0ff875710bfadb7ad42badb931b0fd50"
+    RULES_JVM_EXTERNAL_TAG = "6.3"
+    RULES_JVM_EXTERNAL_SHA = "c18a69d784bcd851be95897ca0eca0b57dc86bb02e62402f15736df44160eb02"
     maybe(
         http_archive,
         name = "rules_jvm_external",
@@ -88,11 +60,11 @@ def stardoc_repositories():
     maybe(
         http_archive,
         name = "rules_license",
+        sha256 = "26d4021f6898e23b82ef953078389dd49ac2b5618ac564ade4ef87cced147b38",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
-            "https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz",
+            "https://github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz",
         ],
-        sha256 = "4531deccb913639c30e5c7512a054d5d875698daeb75d8cf90f284375fe7c360",
     )
 
     # Transitive dep of com_google_protobuf. Unfortunately, protobuf_deps()
@@ -121,33 +93,7 @@ def stardoc_repositories():
     maybe(
         http_archive,
         name = "rules_python",
-        sha256 = "a644da969b6824cc87f8fe7b18101a8a6c57da5db39caa6566ec6109f37d2141",
-        strip_prefix = "rules_python-0.20.0",
-        url = "https://github.com/bazelbuild/rules_python/releases/download/0.20.0/rules_python-0.20.0.tar.gz",
+        sha256 = "690e0141724abb568267e003c7b6d9a54925df40c275a870a4d934161dc9dd53",
+        strip_prefix = "rules_python-0.40.0",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.40.0/rules_python-0.40.0.tar.gz",
     )
-
-    ## Fail: rules_cc defs.bzl doesn't have cc_proto_library via
-    ##maybe(
-    ##    http_archive,
-    ##    name = "rules_cc",
-    ##    sha256 = "4b12149a041ddfb8306a8fd0e904e39d673552ce82e4296e96fac9cbf0780e59",
-    ##    strip_prefix = "rules_cc-0.1.0",
-    ##    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.0/rules_cc-0.1.0.tar.gz"],
-    ##)
-
-    maybe(
-        http_archive,
-        name = "rules_cc",
-        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.17/rules_cc-0.0.17.tar.gz"],
-        sha256 = "abc605dd850f813bb37004b77db20106a19311a96b2da1c92b789da529d28fe1",
-        strip_prefix = "rules_cc-0.0.17",
-    )
-
-    ## Not tried
-    ##maybe(
-    ##    http_archive,
-    ##    name = "rules_cc",
-    ##    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.16/rules_cc-0.0.16.tar.gz"],
-    ##    sha256 = "bbf1ae2f83305b7053b11e4467d317a7ba3517a12cef608543c1b1c5bf48a4df",
-    ##    strip_prefix = "rules_cc-0.0.16",
-    ##)

--- a/setup.bzl
+++ b/setup.bzl
@@ -61,9 +61,9 @@ def stardoc_repositories():
         http_archive,
         name = "rules_java",
         urls = [
-            "https://github.com/bazelbuild/rules_java/releases/download/8.0.0-rc1/rules_java-8.0.0-rc1.tar.gz",
+            "https://github.com/bazelbuild/rules_java/releases/download/7.12.1/rules_java-7.12.1.tar.gz",
         ],
-        sha256 = "b2441c2afdc3b79fba75721c5c5ccbca947f15cc7f107c033efa18845933f975",
+        sha256 = "dfbadbb37a79eb9e1cc1e156ecb8f817edf3899b28bc02410a6c1eb88b1a6862",
     )
 
     RULES_JVM_EXTERNAL_TAG = "6.1"

--- a/setup.bzl
+++ b/setup.bzl
@@ -22,12 +22,21 @@ def stardoc_repositories():
     maybe(
         http_archive,
         name = "bazel_skylib",
-        sha256 = "9f38886a40548c6e96c106b752f242130ee11aaa068a56ba7e56f4511f33e4f2",
+        sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
         ],
     )
+    ##maybe(
+    ##    http_archive,
+    ##    name = "bazel_skylib",
+    ##    sha256 = "9f38886a40548c6e96c106b752f242130ee11aaa068a56ba7e56f4511f33e4f2",
+    ##    urls = [
+    ##        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz",
+    ##        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz",
+    ##    ],
+    ##)
 
     ##maybe(
     ##    http_archive,
@@ -117,6 +126,7 @@ def stardoc_repositories():
         url = "https://github.com/bazelbuild/rules_python/releases/download/0.20.0/rules_python-0.20.0.tar.gz",
     )
 
+    ## Fail: rules_cc defs.bzl doesn't have cc_proto_library via
     ##maybe(
     ##    http_archive,
     ##    name = "rules_cc",
@@ -124,6 +134,7 @@ def stardoc_repositories():
     ##    strip_prefix = "rules_cc-0.1.0",
     ##    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.0/rules_cc-0.1.0.tar.gz"],
     ##)
+
     maybe(
         http_archive,
         name = "rules_cc",
@@ -131,3 +142,12 @@ def stardoc_repositories():
         sha256 = "abc605dd850f813bb37004b77db20106a19311a96b2da1c92b789da529d28fe1",
         strip_prefix = "rules_cc-0.0.17",
     )
+
+    ## Not tried
+    ##maybe(
+    ##    http_archive,
+    ##    name = "rules_cc",
+    ##    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.16/rules_cc-0.0.16.tar.gz"],
+    ##    sha256 = "bbf1ae2f83305b7053b11e4467d317a7ba3517a12cef608543c1b1c5bf48a4df",
+    ##    strip_prefix = "rules_cc-0.0.16",
+    ##)

--- a/stardoc/proto/BUILD
+++ b/stardoc/proto/BUILD
@@ -1,5 +1,5 @@
+load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_java//java:defs.bzl", "java_proto_library")
 
 licenses(["notice"])
 

--- a/stardoc/proto/BUILD
+++ b/stardoc/proto/BUILD
@@ -1,3 +1,4 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
 
 licenses(["notice"])


### PR DESCRIPTION
The load for proto_library is missing, which breaks when used with Bazel 8.

Fixes https://github.com/bazelbuild/stardoc/issues/261