### PR TITLE
chore: setup a github action to create releases

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,3 @@
+fixedReleaser:
+  login: tetromino
+  email: arostovtsev@google.com

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,20 @@
+{
+  "homepage": "https://github.com/bazelbuild/stardoc",
+  "maintainers": [
+    {
+      "name": "Alexandre Rostovtsev",
+      "email": "arostovtsev@google.com",
+      "github": "tetromino"
+    },
+    {
+      "name": "Jon Brandvein",
+      "email": "brandjon@google.com",
+      "github": "brandjon"
+    }
+  ],
+  "repository": [
+    "github:bazelbuild/stardoc"
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+  bazel:
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@stardoc//stardoc/...'

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -5,7 +5,7 @@ matrix:
   - macos
   - windows
   bazel:
-  - 7.x
+  - 8.x
 tasks:
   verify_targets:
     name: Verify build targets

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,4 @@
 {
   "integrity": "**leave this alone**",
-  "strip_prefix": "{REPO}-{VERSION}",
   "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
 }

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "**leave this alone**",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
+}

--- a/.github/workflows/create_archive_and_notes.sh
+++ b/.github/workflows/create_archive_and_notes.sh
@@ -18,8 +18,6 @@ set -o errexit -o nounset -o pipefail
 # Set by GH actions, see
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 TAG=${GITHUB_REF_NAME}
-# A prefix is added to better match the GitHub generated archives.
-PREFIX="stardoc-${TAG}"
 ARCHIVE="stardoc-$TAG.tar.gz"
 
 bazel build //distro:distro
@@ -53,7 +51,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "io_bazel_stardoc",
     sha256 = "${SHA}",
-    strip_prefix = "${PREFIX}",
     url = "https://github.com/bazelbuild/stardoc/releases/download/${TAG}/stardoc-${TAG}.tar.gz",
 )
 

--- a/.github/workflows/create_archive_and_notes.sh
+++ b/.github/workflows/create_archive_and_notes.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+# Set by GH actions, see
+# https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+TAG=${GITHUB_REF_NAME}
+# A prefix is added to better match the GitHub generated archives.
+PREFIX="stardoc-${TAG}"
+ARCHIVE="stardoc-$TAG.tar.gz"
+
+bazel build //distro:distro
+# Copy it locally so release.yml sees it
+cp bazel-bin/distro/stardoc-*.tar.gz $ARCHIVE
+
+SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
+
+cat > release_notes.txt << EOF
+
+## MODULE.bazel setup
+
+Add to your \`MODULE.bazel\` file:
+
+\`\`\`starlark
+bazel_dep(name = "stardoc", version = "${TAG}")
+\`\`\`
+
+By default - in other words, when using Bzlmod for dependency management -
+Stardoc uses @stardoc as its repo name. The legacy WORSKSPACE setup (see below)
+used @io_bazel_stardoc instead. For compatibility with the legacy WORKSPACE
+setup, you may add repo_name = "io_bazel_stardoc" to the bazel_dep call.
+
+## Legacy WORKSPACE setup
+
+To use Stardoc, add the following to your WORKSPACE file:
+
+\`\`\`starlark
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_stardoc",
+    sha256 = "${SHA}",
+    strip_prefix = "${PREFIX}",
+    url = "https://github.com/bazelbuild/stardoc/releases/download/${TAG}/stardoc-${TAG}.tar.gz",
+)
+
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
+stardoc_repositories()
+
+load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
+
+rules_java_dependencies()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
+
+rules_jvm_external_deps()
+
+load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
+
+rules_jvm_external_setup()
+
+load("@io_bazel_stardoc//:deps.bzl", "stardoc_external_deps")
+
+stardoc_external_deps()
+
+load("@stardoc_maven//:defs.bzl", stardoc_pinned_maven_install = "pinned_maven_install")
+
+stardoc_pinned_maven_install()
+
+\`\`\`
+
+The sequence of function calls and load statements after the io_bazel_stardoc
+repository definition ensures that this repository's dependencies are loaded
+(each function call defines additional repositories for Stardoc's dependencies,
+which are then used by subsequent load statements).
+
+Note that WORKSPACE files are sensitive to the order of dependencies. If, after
+updating to a newer version of Stardoc, you encounter "not a valid
+maven_install.json file" or other repository fetch errors (example: #186), try
+moving the Stardoc dependency block above or below other dependencies in your
+WORKSPACE file.
+
+EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ name: Release
 on:
   push:
     tags:
-      - "*.*.*"
+      - "[0-9]+.[0-9.]+"
 
 jobs:
   build:
@@ -30,9 +30,10 @@ jobs:
         uses: bazel-contrib/setup-bazel@0.9.1
       - name: Create release archive and notes
         run: .github/workflows/create_archive_and_notes.sh
-      - name: Release
+      - name: Draft a release
         uses: softprops/action-gh-release@v2
         with:
+          draft: true
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true
           body_path: release_notes.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cut a release whenever a new tag is pushed to the repo.
+name: Release
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.9.1
+      - name: Create release archive and notes
+        run: .github/workflows/create_archive_and_notes.sh
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          # Use GH feature to populate the changelog automatically
+          generate_release_notes: true
+          body_path: release_notes.txt
+          fail_on_unmatched_files: true
+          files: stardoc-*.tar.gz
+


### PR DESCRIPTION
This defines up a GitHub action to create a Github release and BCR configs for the Publish
To BCR app.

Creating a `X.Y.Z` tag will trigger the action.