### PR TITLE
Fix CI failures

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -88,13 +88,6 @@ tasks:
     - "//test:macro_kwargs_legacy_test"
     skip_in_bazel_downstream_pipeline: Manual tests requiring an older Bazel version
 
-  bazel_8_tests:
-    name: Stardoc golden tests requiring Bazel 8
-    platform: ubuntu2004
-    bazel: 8.0.0
-    test_targets:
-    - "//test:macro_kwargs_test"
-
   # TODO: enable these by default once Bazel 8.0.1 is released
   bazel_8_0_1_tests:
     name: Stardoc golden tests requiring Bazel 8.0.1 or newer

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -95,4 +95,17 @@ tasks:
     test_targets:
     - "//test:macro_kwargs_test"
 
+  # TODO: enable these by default once Bazel 8.0.1 is released
+  bazel_8_0_1_tests:
+    name: Stardoc golden tests requiring Bazel 8.0.1 or newer
+    platform: ubuntu2004
+    bazel: last_green  # until 8.0.1 is released
+    test_targets:
+    - "//test:angle_bracket_test"
+    - "//test:aspect_test"
+    - "//test:attribute_defaults_test"
+    - "//test:html_tables_template_test"
+    - "//test:pure_markdown_template_test"
+    - "//test:table_of_contents_test"
+
 buildifier: latest

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -79,19 +79,19 @@ tasks:
     platform: windows
     working_directory: test/bzlmod
 
-  bazel_7_2_tests:
-    name: Stardoc golden tests requiring Bazel 7.2
+  bazel_7_tests:
+    name: Stardoc golden tests requiring Bazel 7
     platform: ubuntu2004
-    bazel: 7.2.0
+    bazel: 7.4.1
     test_targets:
     - "//test:proto_format_test"
     - "//test:macro_kwargs_legacy_test"
     skip_in_bazel_downstream_pipeline: Manual tests requiring an older Bazel version
 
   bazel_8_tests:
-    name: Stardoc golden tests requiring Bazel HEAD
+    name: Stardoc golden tests requiring Bazel 8
     platform: ubuntu2004
-    bazel: last_green
+    bazel: 8.0.0
     test_targets:
     - "//test:macro_kwargs_test"
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -31,12 +31,22 @@ stardoc_test(
     input_file = "testdata/input_template_test/input.bzl",
     provider_template = "testdata/input_template_test/provider.vm",
     rule_template = "testdata/input_template_test/rule.vm",
+    # Remove tags and enable by default once Bazel 8.0.1 is released
+    tags = [
+        "bazel_8_0_1",
+        "manual",
+    ],
 )
 
 stardoc_test(
     name = "angle_bracket_test",
     golden_file = "testdata/angle_bracket_test/golden.md",
     input_file = "testdata/angle_bracket_test/input.bzl",
+    # Remove tags and enable by default once Bazel 8.0.1 is released
+    tags = [
+        "bazel_8_0_1",
+        "manual",
+    ],
 )
 
 stardoc_test(
@@ -244,6 +254,11 @@ stardoc_test(
     name = "pure_markdown_template_test",
     golden_file = "testdata/pure_markdown_template_test/golden.md",
     input_file = "testdata/pure_markdown_template_test/input.bzl",
+    # Remove tags and enable by default once Bazel 8.0.1 is released
+    tags = [
+        "bazel_8_0_1",
+        "manual",
+    ],
 )
 
 stardoc_test(
@@ -263,6 +278,11 @@ stardoc_test(
     name = "aspect_test",
     golden_file = "testdata/aspect_test/golden.md",
     input_file = "testdata/aspect_test/input.bzl",
+    # Remove tags and enable by default once Bazel 8.0.1 is released
+    tags = [
+        "bazel_8_0_1",
+        "manual",
+    ],
 )
 
 stardoc_test(
@@ -279,12 +299,22 @@ stardoc_test(
     golden_file = "testdata/html_tables_template_test/golden.md",
     input_file = "testdata/html_tables_template_test/input.bzl",
     test = "html_tables",
+    # Remove tags and enable by default once Bazel 8.0.1 is released
+    tags = [
+        "bazel_8_0_1",
+        "manual",
+    ],
 )
 
 stardoc_test(
     name = "attribute_defaults_test",
     golden_file = "testdata/attribute_defaults_test/golden.md",
     input_file = "testdata/attribute_defaults_test/input.bzl",
+    # Remove tags and enable by default once Bazel 8.0.1 is released
+    tags = [
+        "bazel_8_0_1",
+        "manual",
+    ],
 )
 
 stardoc_test(
@@ -309,6 +339,11 @@ bzl_library(
         "testdata/provider_basic_test/input.bzl",
         "testdata/repo_rules_test/input.bzl",
         "testdata/simple_test/input.bzl",
+    ],
+    # Remove tags and enable by default once Bazel 8.0.1 is released
+    tags = [
+        "bazel_8_0_1",
+        "manual",
     ],
 )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -243,11 +243,6 @@ stardoc_test(
     name = "macro_kwargs_test",
     golden_file = "testdata/macro_kwargs_test/golden.md",
     input_file = "testdata/macro_kwargs_test/input.bzl",
-    # Golden output was generated with Bazel 8.0.0 and may differ in other versions
-    tags = [
-        "bazel_8",
-        "manual",
-    ],
 )
 
 stardoc_test(

--- a/test/BUILD
+++ b/test/BUILD
@@ -342,6 +342,11 @@ stardoc_test(
     golden_file = "testdata/table_of_contents_test/golden.md",
     input_file = "testdata/table_of_contents_test/input.bzl",
     table_of_contents_template = "//stardoc:templates/markdown_tables/table_of_contents.vm",
+    # Remove tags and enable by default once Bazel 8.0.1 is released
+    tags = [
+        "bazel_8_0_1",
+        "manual",
+    ],
     deps = [":table_of_contents_test_deps"],
 )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -13,7 +13,7 @@ self_gen_test(
     name = "stardoc_self_gen_test",
     golden_file = "//stardoc:stardoc_doc.md",
     stardoc_doc = "//:stardoc_rule_doc",
-    # stardoc_doc.md output was generated with Bazel HEAD on 2024-06-12 and may differ in other versions
+    # stardoc_doc.md output was generated with Bazel 8.0.0 and may differ in other versions
     tags = [
         "bazel_8",
         "manual",
@@ -44,9 +44,9 @@ stardoc_test(
     format = "proto",
     golden_file = "testdata/proto_format_test/golden.binaryproto",
     input_file = "testdata/proto_format_test/input.bzl",
-    # Golden output was generated with Bazel 7.2 and may differ in other versions
+    # Golden output was generated with Bazel 7.4.1 and may differ in other versions
     tags = [
-        "bazel_7_2",
+        "bazel_7",
         "manual",
     ],
 )
@@ -222,9 +222,9 @@ stardoc_test(
     name = "macro_kwargs_legacy_test",
     golden_file = "testdata/macro_kwargs_test/legacy_golden.md",
     input_file = "testdata/macro_kwargs_test/input.bzl",
-    # Golden output was generated with Bazel 7.2 and may differ in other versions
+    # Golden output was generated with Bazel 7.4.1 and may differ in other versions
     tags = [
-        "bazel_7_2",
+        "bazel_7",
         "manual",
     ],
 )
@@ -233,7 +233,7 @@ stardoc_test(
     name = "macro_kwargs_test",
     golden_file = "testdata/macro_kwargs_test/golden.md",
     input_file = "testdata/macro_kwargs_test/input.bzl",
-    # Golden output was generated with Bazel HEAD on 2024-06-12 and may differ in other versions
+    # Golden output was generated with Bazel 8.0.0 and may differ in other versions
     tags = [
         "bazel_8",
         "manual",

--- a/test/BUILD
+++ b/test/BUILD
@@ -288,12 +288,12 @@ stardoc_test(
     name = "html_tables_template_test",
     golden_file = "testdata/html_tables_template_test/golden.md",
     input_file = "testdata/html_tables_template_test/input.bzl",
-    test = "html_tables",
     # Remove tags and enable by default once Bazel 8.0.1 is released
     tags = [
         "bazel_8_0_1",
         "manual",
     ],
+    test = "html_tables",
 )
 
 stardoc_test(

--- a/test/BUILD
+++ b/test/BUILD
@@ -13,11 +13,6 @@ self_gen_test(
     name = "stardoc_self_gen_test",
     golden_file = "//stardoc:stardoc_doc.md",
     stardoc_doc = "//:stardoc_rule_doc",
-    # stardoc_doc.md output was generated with Bazel 8.0.0 and may differ in other versions
-    tags = [
-        "bazel_8",
-        "manual",
-    ],
 )
 
 exports_files(["testdata/fakedeps/dep.bzl"])

--- a/test/testdata/angle_bracket_test/golden.md
+++ b/test/testdata/angle_bracket_test/golden.md
@@ -101,7 +101,7 @@ deprecated for \<reasons> as well as `<reasons>`.
 <pre>
 load("@stardoc//test:testdata/angle_bracket_test/input.bzl", "bracket_aspect")
 
-bracket_aspect(<a href="#bracket_aspect-name">name</a>, <a href="#bracket_aspect-brackets">brackets</a>)
+bracket_aspect(<a href="#bracket_aspect-brackets">brackets</a>)
 </pre>
 
 Aspect.
@@ -125,7 +125,6 @@ which includes angle brackets.
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="bracket_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="bracket_aspect-brackets"></a>brackets |  Attribute with \<brackets>   | String | optional |  `"<default>"`  |
 
 

--- a/test/testdata/aspect_test/golden.md
+++ b/test/testdata/aspect_test/golden.md
@@ -29,7 +29,7 @@ my_aspect_impl(<a href="#my_aspect_impl-ctx">ctx</a>)
 <pre>
 load("@stardoc//test:testdata/aspect_test/input.bzl", "my_aspect")
 
-my_aspect(<a href="#my_aspect-name">name</a>, <a href="#my_aspect-first">first</a>, <a href="#my_aspect-second">second</a>)
+my_aspect(<a href="#my_aspect-first">first</a>, <a href="#my_aspect-second">second</a>)
 </pre>
 
 This is my aspect.
@@ -50,7 +50,6 @@ It does stuff.
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="my_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="my_aspect-first"></a>first |  -   | Boolean | required |  |
 | <a id="my_aspect-second"></a>second |  -   | String | required |  |
 
@@ -62,7 +61,7 @@ It does stuff.
 <pre>
 load("@stardoc//test:testdata/aspect_test/input.bzl", "namespace")
 
-namespace.namespaced_aspect(<a href="#namespace.namespaced_aspect-name">name</a>, <a href="#namespace.namespaced_aspect-third">third</a>)
+namespace.namespaced_aspect(<a href="#namespace.namespaced_aspect-third">third</a>)
 </pre>
 
 This is another aspect.
@@ -76,7 +75,6 @@ This is another aspect.
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="namespace.namespaced_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="namespace.namespaced_aspect-third"></a>third |  -   | Integer | required |  |
 
 
@@ -87,7 +85,7 @@ This is another aspect.
 <pre>
 load("@stardoc//test:testdata/aspect_test/input.bzl", "other_aspect")
 
-other_aspect(<a href="#other_aspect-name">name</a>, <a href="#other_aspect-third">third</a>)
+other_aspect(<a href="#other_aspect-third">third</a>)
 </pre>
 
 This is another aspect.
@@ -101,7 +99,6 @@ This is another aspect.
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="other_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="other_aspect-third"></a>third |  -   | Integer | required |  |
 
 

--- a/test/testdata/attribute_defaults_test/golden.md
+++ b/test/testdata/attribute_defaults_test/golden.md
@@ -52,7 +52,7 @@ This is my rule. It does stuff.
 <pre>
 load("@stardoc//test:testdata/attribute_defaults_test/input.bzl", "my_aspect")
 
-my_aspect(<a href="#my_aspect-name">name</a>, <a href="#my_aspect-y">y</a>, <a href="#my_aspect-z">z</a>)
+my_aspect(<a href="#my_aspect-y">y</a>, <a href="#my_aspect-z">z</a>)
 </pre>
 
 This is my aspect. It does stuff.
@@ -71,7 +71,6 @@ This is my aspect. It does stuff.
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="my_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="my_aspect-y"></a>y |  some string   | String | optional |  `"why"`  |
 | <a id="my_aspect-z"></a>z |  -   | String | required |  |
 

--- a/test/testdata/html_tables_template_test/golden.md
+++ b/test/testdata/html_tables_template_test/golden.md
@@ -172,7 +172,7 @@ This parameter does bar related things.
 <pre>
 load("@stardoc//test:testdata/html_tables_template_test/input.bzl", "example_aspect")
 
-example_aspect(<a href="#example_aspect-name">name</a>, <a href="#example_aspect-first">first</a>, <a href="#example_aspect-second">second</a>)
+example_aspect(<a href="#example_aspect-first">first</a>, <a href="#example_aspect-second">second</a>)
 </pre>
 
 Small example of aspect using a markdown template.
@@ -208,19 +208,6 @@ String; required.
 <col class="col-description" />
 </colgroup>
 <tbody>
-<tr id="example_aspect-name">
-<td><code>name</code></td>
-<td>
-
-<a href="https://bazel.build/concepts/labels#target-names">Name</a>; required
-
-<p>
-
-A unique name for this target.
-
-</p>
-</td>
-</tr>
 <tr id="example_aspect-first">
 <td><code>first</code></td>
 <td>

--- a/test/testdata/input_template_test/golden.md
+++ b/test/testdata/input_template_test/golden.md
@@ -109,7 +109,7 @@ Use `bazel build` to run the check.
 ## my_aspect
 
 <pre>
-my_aspect(<a href="#my_aspect-name">name</a>, <a href="#my_aspect-first">first</a>)
+my_aspect(<a href="#my_aspect-first">first</a>)
 </pre>
 
 This is my aspect. It does stuff.
@@ -123,13 +123,6 @@ This is my aspect. It does stuff.
 
 ### Attributes
 
-<b>
-      <code>name</code>
-        <a href="https://bazel.build/concepts/labels#target-names">Name</a>; required
-</b>
-        <p>
-          A unique name for this target.
-        </p>
 <b>
       <code>first</code>
         String; required

--- a/test/testdata/providers_for_attributes_test/input.bzl
+++ b/test/testdata/providers_for_attributes_test/input.bzl
@@ -35,8 +35,7 @@ my_rule = rule(
             providers = [OtherProviderInfo],
         ),
         "fourth": attr.label(
-            # buildifier: disable=native-proto
-            providers = [ProtoInfo, DefaultInfo],
+            providers = [DefaultInfo],
         ),
         "fifth": attr.label(
             providers = [["LegacyProvider", "ObjectProvider"], [DefaultInfo]],

--- a/test/testdata/pure_markdown_template_test/golden.md
+++ b/test/testdata/pure_markdown_template_test/golden.md
@@ -73,7 +73,7 @@ Small example of function using a markdown template.
 <pre>
 load("@stardoc//test:testdata/pure_markdown_template_test/input.bzl", "example_aspect")
 
-example_aspect(<a href="#example_aspect-name">name</a>, <a href="#example_aspect-first">first</a>, <a href="#example_aspect-second">second</a>)
+example_aspect(<a href="#example_aspect-first">first</a>, <a href="#example_aspect-second">second</a>)
 </pre>
 
 Small example of aspect using a markdown template.
@@ -92,7 +92,6 @@ Small example of aspect using a markdown template.
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="example_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="example_aspect-first"></a>first |  -   | String | required |  |
 | <a id="example_aspect-second"></a>second |  This is the second attribute.   | String | optional |  `""`  |
 

--- a/test/testdata/table_of_contents_test/golden.md
+++ b/test/testdata/table_of_contents_test/golden.md
@@ -160,7 +160,7 @@ A suffixed version of the name.
 <pre>
 load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "my_aspect")
 
-my_aspect(<a href="#my_aspect-name">name</a>, <a href="#my_aspect-first">first</a>, <a href="#my_aspect-second">second</a>)
+my_aspect(<a href="#my_aspect-first">first</a>, <a href="#my_aspect-second">second</a>)
 </pre>
 
 This is my aspect.
@@ -181,7 +181,6 @@ It does stuff.
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="my_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="my_aspect-first"></a>first |  -   | Boolean | required |  |
 | <a id="my_aspect-second"></a>second |  -   | String | required |  |
 
@@ -193,7 +192,7 @@ It does stuff.
 <pre>
 load("@stardoc//test:testdata/table_of_contents_test/input.bzl", "other_aspect")
 
-other_aspect(<a href="#other_aspect-name">name</a>, <a href="#other_aspect-third">third</a>)
+other_aspect(<a href="#other_aspect-third">third</a>)
 </pre>
 
 This is another aspect.
@@ -207,7 +206,6 @@ This is another aspect.
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="other_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="other_aspect-third"></a>third |  -   | Integer | required |  |
 
 

--- a/update-stardoc-tests.sh
+++ b/update-stardoc-tests.sh
@@ -60,9 +60,9 @@ function regenerate () {
 : "${BAZEL:=bazelisk}"
 
 update_non_manual_tests
-update_manual_tests_with_tag "noenable_bzlmod" --noenable_bzlmod
-USE_BAZEL_VERSION="7.2.0" update_manual_tests_with_tag "bazel_7_2"
-USE_BAZEL_VERSION="8.0.0-pre.20240603.2" update_manual_tests_with_tag "bazel_8"
+update_manual_tests_with_tag "noenable_bzlmod" --noenable_bzlmod --enable_workspace
+USE_BAZEL_VERSION="7.4.1" update_manual_tests_with_tag "bazel_7"
+USE_BAZEL_VERSION="8.0.0" update_manual_tests_with_tag "bazel_8"
 
 echo "** Files copied."
 echo "Please note that not all golden files are correctly copied by this script."

--- a/update-stardoc-tests.sh
+++ b/update-stardoc-tests.sh
@@ -63,6 +63,7 @@ update_non_manual_tests
 update_manual_tests_with_tag "noenable_bzlmod" --noenable_bzlmod --enable_workspace
 USE_BAZEL_VERSION="7.4.1" update_manual_tests_with_tag "bazel_7"
 USE_BAZEL_VERSION="8.0.0" update_manual_tests_with_tag "bazel_8"
+USE_BAZEL_VERSION="9c178d23de4368ee0d91386469d1a5fd9f0254e4" update_manual_tests_with_tag "bazel_8_0_1"  # 9c178d23de4368ee0d91386469d1a5fd9f0254e4 is tip of release-8.0.1 branch as of 2025-01-09
 
 echo "** Files copied."
 echo "Please note that not all golden files are correctly copied by this script."

--- a/update-stardoc-tests.sh
+++ b/update-stardoc-tests.sh
@@ -62,7 +62,6 @@ function regenerate () {
 update_non_manual_tests
 update_manual_tests_with_tag "noenable_bzlmod" --noenable_bzlmod --enable_workspace
 USE_BAZEL_VERSION="7.4.1" update_manual_tests_with_tag "bazel_7"
-USE_BAZEL_VERSION="8.0.0" update_manual_tests_with_tag "bazel_8"
 USE_BAZEL_VERSION="9c178d23de4368ee0d91386469d1a5fd9f0254e4" update_manual_tests_with_tag "bazel_8_0_1"  # 9c178d23de4368ee0d91386469d1a5fd9f0254e4 is tip of release-8.0.1 branch as of 2025-01-09
 
 echo "** Files copied."


### PR DESCRIPTION
Remove unnecessary usage of ProtoInfo (which is no longer native and thus no longer needs special testing); enable tests requiring Bazel 8.0.0 by default; temporarily disable tests requiring Bazel 8.0.1 (more specifically - requiring starlark_doc_extract changes cherry-picked into 8.0.1 by https://github.com/bazelbuild/bazel/issues/24643) by default but test them using latest_green.