### PR TITLE
Remove legacy struct providers from test

### DIFF
--- a/test/testdata/providers_for_attributes_test/golden.md
+++ b/test/testdata/providers_for_attributes_test/golden.md
@@ -9,7 +9,7 @@ The input file for the providers for attributes test
 <pre>
 load("@stardoc//test:testdata/providers_for_attributes_test/input.bzl", "my_rule")
 
-my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-fifth">fifth</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-fourth">fourth</a>, <a href="#my_rule-second">second</a>, <a href="#my_rule-sixth">sixth</a>, <a href="#my_rule-third">third</a>)
+my_rule(<a href="#my_rule-name">name</a>, <a href="#my_rule-first">first</a>, <a href="#my_rule-fourth">fourth</a>, <a href="#my_rule-second">second</a>, <a href="#my_rule-third">third</a>)
 </pre>
 
 This rule does things.
@@ -20,11 +20,9 @@ This rule does things.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="my_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="my_rule-fifth"></a>fifth |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="my_rule-first"></a>first |  this is the first attribute.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
 | <a id="my_rule-fourth"></a>fourth |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="my_rule-second"></a>second |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="my_rule-sixth"></a>sixth |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="my_rule-third"></a>third |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 
 

--- a/test/testdata/providers_for_attributes_test/input.bzl
+++ b/test/testdata/providers_for_attributes_test/input.bzl
@@ -37,11 +37,5 @@ my_rule = rule(
         "fourth": attr.label(
             providers = [DefaultInfo],
         ),
-        "fifth": attr.label(
-            providers = [["LegacyProvider", "ObjectProvider"], [DefaultInfo]],
-        ),
-        "sixth": attr.label(
-            providers = ["LegacyProvider"],
-        ),
     },
 )


### PR DESCRIPTION
Legacy struct providers have been deprecated by Bazel and will be removed.

Original author: Ivo List <ilist@google.com>