### PR TITLE
Improve exception message when encountering unknown attribute types, and sync stardoc_output.proto

### DIFF
--- a/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownUtil.java
+++ b/src/main/java/com/google/devtools/build/stardoc/rendering/MarkdownUtil.java
@@ -27,7 +27,6 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.AspectInfo;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.AttributeInfo;
-import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.AttributeType;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.FunctionParamInfo;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.MacroInfo;
 import com.google.devtools.build.lib.starlarkdocextract.StardocOutputProtos.ModuleExtensionInfo;
@@ -530,11 +529,10 @@ public final class MarkdownUtil {
     }
     String typeString;
     if (typeLink == null) {
-      typeString = attributeTypeDescription(attrInfo.getType());
+      typeString = attributeTypeDescription(attrInfo);
     } else {
       typeString =
-          String.format(
-              "<a href=\"%s\">%s</a>", typeLink, attributeTypeDescription(attrInfo.getType()));
+          String.format("<a href=\"%s\">%s</a>", typeLink, attributeTypeDescription(attrInfo));
     }
     if (attrInfo.getNonconfigurable()) {
       typeString +=
@@ -572,8 +570,8 @@ public final class MarkdownUtil {
     return Joiner.on("; or ").join(finalProviderNames);
   }
 
-  private static String attributeTypeDescription(AttributeType attributeType) {
-    switch (attributeType) {
+  private static String attributeTypeDescription(AttributeInfo attrInfo) {
+    switch (attrInfo.getType()) {
       case NAME:
         return "Name";
       case INT:
@@ -604,9 +602,14 @@ public final class MarkdownUtil {
         return "List of labels";
       case UNKNOWN:
       case UNRECOGNIZED:
-        throw new IllegalArgumentException("Unhandled type " + attributeType);
+        // fall through
     }
-    throw new IllegalArgumentException("Unhandled type " + attributeType);
+    // We throw here rather than in the switch statement to support building against an external
+    // .proto definition.
+    throw new IllegalArgumentException(
+        String.format(
+            "Attribute '%s' has unsupported attribute type %d (%s)",
+            attrInfo.getName(), attrInfo.getTypeValue(), attrInfo.getType()));
   }
 
   /**

--- a/stardoc/proto/stardoc_output.proto
+++ b/stardoc/proto/stardoc_output.proto
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 // Vendored from src/main/protobuf/stardoc_output.proto
-// in the Bazel source tree at commit 106903d38f6d41b5eb1f100698f257184bea47a3
+// in the Bazel source tree at commit 58cd0a15421529a957bfb0f7fca1b188930dc5b5
 
 //
 // Protos for Stardoc data.
@@ -52,6 +52,8 @@ message ModuleInfo {
   repeated RepositoryRuleInfo repository_rule_info = 8;
 
   repeated MacroInfo macro_info = 9;
+
+  repeated StarlarkOtherSymbolInfo starlark_other_symbol_info = 10;
 }
 
 // Representation of a Starlark rule attribute type. These generally
@@ -172,6 +174,10 @@ message AttributeInfo {
 
   // If true, the attribute is defined in Bazel's native code, not in Starlark.
   bool natively_defined = 8;
+
+  // If non-empty, the string representations of the allowed values for this
+  // attribute.
+  repeated string values = 9;
 }
 
 // Representation of a set of providers.
@@ -399,6 +405,21 @@ message RepositoryRuleInfo {
   // The Starlark module where and the name under which the repository rule was
   // originally declared.
   OriginKey origin_key = 5;
+}
+
+// Representation of a Starlark symbol whose value is of type which lacks
+// built-in docstring and needs to be documented using `#:`-prefixed doc
+// comments; for example, a bool, dict, float, int, list, range, set, string,
+// struct, or tuple.
+message StarlarkOtherSymbolInfo {
+  // The name of the symbol.
+  string name = 1;
+
+  // The content of the symbol's doc comments.
+  string doc = 2;
+
+  // The symbol's value's data type.
+  string type_name = 3;
 }
 
 // Representation of the origin of a rule, provider, aspect, or function.


### PR DESCRIPTION
See https://github.com/bazelbuild/stardoc/issues/307